### PR TITLE
VMware ESXi and vCenter access broker scripts

### DIFF
--- a/VMware/ESXi/README.md
+++ b/VMware/ESXi/README.md
@@ -1,0 +1,45 @@
+# VMware ESXi
+
+Template scripts for **standalone VMware ESXi** hypervisors (not managed through vCenter). All scripts use the vSphere SOAP API at `https://<host>/sdk` — no agent, no SSH, no extra infrastructure. Adapt them for your environment as needed.
+
+> Standalone ESXi only supports JIT access via local-account creation. vCenter offers richer options (SSO group membership, role grants without local accounts) and will be covered separately when added.
+
+---
+
+## Subdirectories
+
+| Directory | Purpose |
+|---|---|
+| [`permissions/temp-local-admin/`](permissions/temp-local-admin/README.md) | JIT checkout/checkin of ephemeral local accounts (works for ESXi web UI **or** SSH access) |
+| [`rotate/`](rotate/README.md) | Rotate the stored secret of an existing local account |
+| [`scans/`](scans/README.md) | Enumerate local accounts and groups for Britive's identity inventory |
+
+---
+
+## Target
+
+| Attribute | Value |
+|---|---|
+| **Platform** | VMware ESXi (standalone) |
+| **Tested versions** | ESXi 7.0, 8.0 |
+| **API** | vSphere SOAP at `https://<host>/sdk` |
+| **Port** | TCP 443 |
+| **Auth** | Local accounts on the host |
+
+---
+
+## Common Prerequisites
+
+The same prerequisites apply to every script in this directory:
+
+- A service account on the ESXi host with the **Administrator** role (or a custom role with `Host.Local.CreateUser`, `Host.Local.RemoveUser`, `Host.Local.ManageUserGroups`, `Authorization.ModifyPermissions`).
+- Outbound TCP 443 from the broker host to each target ESXi host.
+- `python3` 3.8+ on the broker host (standard library only — no third-party packages).
+
+Each subdirectory README covers ESXi-side setup and Britive Platform setup specific to that script.
+
+---
+
+## ESXi Licensing
+
+Write operations against the vSphere SOAP API — creating users, assigning roles, rotating secrets, starting services — require **vSphere Standard or higher** on the host. Free-edition / unlicensed ESXi disables write API calls after the 60-day evaluation period; only read operations continue to work, which means `permissions/`, `rotate/`, and the user-creation paths in these scripts will fail with a fault. The `scans/` script will continue to work because it only reads. vCenter installs (in [`../vCenter/`](../vCenter/README.md)) always include a paid license, so vCenter scripts have no licensing concern.

--- a/VMware/ESXi/permissions/temp-local-admin/README.md
+++ b/VMware/ESXi/permissions/temp-local-admin/README.md
@@ -1,0 +1,179 @@
+# temp-local-admin
+
+Template checkout / checkin scripts for JIT admin access to a standalone **VMware ESXi** host. The same JIT account works for **either the host web UI or SSH** — the script creates the account with shell access enabled (`shellAccess=true`), so it can be used both ways. SSH is only usable if the host's SSH service is enabled (it is disabled by default on ESXi). Adapt for your environment — common customer adjustments include changing the JIT account naming convention, scoping the role grant to a non-root inventory object, or replacing the Administrator role with a custom least-privilege role.
+
+On checkout, an ephemeral local account is created on the host and granted the Administrator role at the root inventory object. The account name is the requestor's email local part — `clint.pollock@example.com` becomes `clint.pollock` — so the audit trail on the ESXi host names the actual person, not a synthetic JIT identifier. The requestor receives the host UI URL, an SSH command, and the ephemeral sign-in credentials. On checkin, the role assignment is removed and the account is deleted. All API calls go to the vSphere SOAP endpoint at `https://<host>/sdk` — no SSH, no agent, no extra infrastructure on the broker side.
+
+> Standalone ESXi only supports JIT via creation of an ephemeral local account — there is no SSO/AD integration on a single host. vCenter (planned) offers other options like SSO group membership and role grants on existing identities.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `checkout.py` | Create the JIT account + assign Administrator + return host URL, SSH command, and credentials |
+| `checkin.py` | Remove the JIT account's role assignment + delete the account |
+
+---
+
+## Environment Variables
+
+### Required (set by Britive)
+
+| Variable | Description |
+| --- | --- |
+| `ESXI_HOST` | IP or hostname of the target ESXi host |
+| `ESXI_SVC_USER` | Service account on the host (must hold the Administrator role) |
+| `ESXI_SVC_PASSWORD` | Service account secret |
+| `BRITIVE_USER_EMAIL` | Britive user email — used to derive the JIT account name (both checkout and checkin) |
+
+### Optional (with defaults)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ESXI_VERIFY_TLS` | `false` | Set `true` to verify TLS — most standalone ESXi hosts use self-signed certs |
+
+---
+
+## How It Works
+
+### Checkout (`checkout.py`)
+
+1. Derives the JIT account name from `BRITIVE_USER_EMAIL` — the lowercase email local part with anything outside `[a-z0-9._-]` stripped (e.g. `clint.pollock@example.com` → `clint.pollock`).
+2. Generates an ephemeral sign-in secret (random, 18 chars).
+3. Calls `Login` on `ha-sessionmgr` to authenticate the service account.
+4. Calls `CreateUser` on `ha-localacctmgr` to create the JIT account with `shellAccess=true`. If the account already exists, `UpdateUser` is called instead to refresh the secret. ⚠ **See "Name Collision" below.**
+5. Calls `SetEntityPermissions` on `ha-authmgr` to bind the JIT account to the Administrator role at `ha-folder-root` with `propagate=true`.
+6. Calls `Logout` and returns:
+   ```json
+   {"status": "checked_out", "target_host": "<host>", "access_url": "https://<host>/ui", "ssh_command": "ssh <jit-name>@<host>", "username": "<jit-name>", "password": "<ephemeral-secret>", "note": "..."}
+   ```
+
+### Checkin (`checkin.py`)
+
+1. Derives the JIT account name the same way checkout did, from `BRITIVE_USER_EMAIL`.
+2. Calls `Login` on `ha-sessionmgr` to authenticate the service account.
+3. Calls `RemoveEntityPermission` on `ha-authmgr` to drop the role binding for that account.
+4. Calls `RemoveUser` on `ha-localacctmgr` to delete the account.
+5. Faults of type `NotFound` / `UserNotFound` are treated as success — checkin is idempotent.
+6. Calls `Logout` and returns:
+   ```json
+   {"status": "revoked", "target_host": "<host>", "removed_user": "<jit-name>"}
+   ```
+
+---
+
+## Name Collision
+
+Because the JIT account name is the email local part with no prefix, a checkout for `clint.pollock@example.com` will hit any pre-existing local account named `clint.pollock` on the host — and the script's "AlreadyExists → UpdateUser" path will **overwrite that account's secret** with the ephemeral JIT secret. On checkin, the account will then be deleted.
+
+**This is fine when ESXi local accounts are managed exclusively through Britive.** If the host has manually-created admin accounts that share names with Britive user emails, you have two options:
+
+1. Keep this behavior and ensure manually-created accounts on the host don't share names with Britive user emails.
+2. Reintroduce a small prefix in `jit_username()` (e.g. `b-clint.pollock`) so JIT accounts can never collide with manually-created ones.
+
+---
+
+## ESXi Host Setup
+
+### 1. Create the service account
+
+Sign in to the ESXi Host Client as `root`:
+
+1. **Manage → Security & users → Users → Add user**.
+2. Create the service account (e.g. `britive-svc`).
+
+### 2. Assign the Administrator role
+
+1. **Host → Actions → Permissions → Add user**.
+2. Select the service account and assign the **Administrator** role at the root inventory object with **Propagate to children** checked.
+
+### 3. (Optional) Use a custom role instead of Administrator
+
+If your security policy does not permit a standing Administrator account for the broker, create a custom role with at minimum:
+
+- `Host.Local.CreateUser`
+- `Host.Local.RemoveUser`
+- `Host.Local.ManageUserGroups`
+- `Authorization.ModifyPermissions`
+
+### 4. (Optional) Enable SSH on the host
+
+The JIT account is created with shell access enabled, but the host's SSH service must be running for the SSH path to work. SSH is disabled by default on ESXi. To enable it permanently:
+
+1. **Manage → Services → TSM-SSH → Start** (and **Actions → Policy → Start and stop with host** to persist across reboots).
+
+If SSH is left disabled, requestors can still use the web UI URL — the SSH command in the checkout output will simply fail to connect.
+
+### 5. Network requirements
+
+- TCP 443 from the broker host to each target ESXi host (SOAP API at `/sdk`).
+- TCP 22 from requestor workstations to each target ESXi host — only if SSH is enabled and you want requestors to use the SSH path.
+
+---
+
+## Broker Container Requirements
+
+- `python3` 3.8+ (standard library only — no third-party packages)
+- Outbound TCP 443 to each target ESXi host
+
+---
+
+## Britive Platform Setup
+
+1. Create a broker pool connected to your broker deployment.
+2. Create an `ESXi` resource type with `checkout.py` as the checkout script and `checkin.py` as the checkin script.
+3. Set the following script parameters on the permission:
+
+   **Always required:** `ESXI_HOST`, `ESXI_SVC_USER`, `ESXI_SVC_PASSWORD`
+
+   **Optional:** `ESXI_VERIFY_TLS`
+
+4. Mark `ESXI_SVC_PASSWORD` as **sensitive** so it's encrypted at rest and injected securely at runtime.
+5. Set the response template so the requestor sees `{{access_url}}`, `{{ssh_command}}`, `{{username}}`, and `{{password}}` from the checkout output.
+6. Assign users or tags to the profile policy.
+
+---
+
+## Example: Manual Test Run
+
+```sh
+export ESXI_HOST="esxi-01.example.com"
+export ESXI_SVC_USER="britive-svc"
+export ESXI_SVC_PASSWORD="<service-account-secret>"
+export BRITIVE_USER_EMAIL="clint.pollock@example.com"
+
+python3 checkout.py
+# {"status": "checked_out", "access_url": "https://esxi-01.example.com/ui",
+#  "ssh_command": "ssh clint.pollock@esxi-01.example.com",
+#  "username": "clint.pollock", ...}
+
+# To clean up (uses ESXI_HOST + ESXI_SVC_USER + ESXI_SVC_PASSWORD + BRITIVE_USER_EMAIL from above):
+python3 checkin.py
+# {"status": "revoked", "removed_user": "clint.pollock"}
+```
+
+---
+
+## Possible Extension: enable SSH on the host at checkout
+
+The JIT account is created with shell access enabled, but the SSH path only works if the host's `TSM-SSH` service is running — and it's disabled by default on ESXi. `checkout.py` includes a commented-out `esxi_start_ssh_service()` helper that calls `StartService` on `HostServiceSystem` to bring SSH up automatically at checkout, gated on an opt-in `ESXI_ENABLE_SSH=true` env var.
+
+**This extension is untested** in this template. Before enabling it:
+
+- Verify the `HostServiceSystem` MOID on your host (the script uses `serviceSystem`, the standard for standalone ESXi).
+- Grant the service account `Host.Config.Settings` in addition to the user/permission privileges it already has.
+- Decide whether checkin should restore the prior service state (read it before starting, stop on checkin if it was off). Not modeled in the commented helper.
+
+A simpler alternative: leave SSH always-on by configuring **Manage → Services → TSM-SSH → Policy → Start and stop with host** in the Host Client (one-time), and let the script just hand back the SSH command.
+
+---
+
+## Session Recording
+
+These scripts return ephemeral credentials to the requestor for direct sign-in (web UI or SSH). **Sessions are not recorded.**
+
+If your environment requires recorded sessions, the recommended pattern is to use the **Britive Bridge** in front of a Windows jump box: have the bridge open the ESXi UI (or an SSH client) inside the recorded jump-box session and inject the JIT credentials at sign-in time, so the secret is never exposed to the requestor. Record the jump box itself via RDP session recording.
+
+That flow is out of scope for this example — it requires bridge + jump-box infrastructure not modeled here.

--- a/VMware/ESXi/permissions/temp-local-admin/README.md
+++ b/VMware/ESXi/permissions/temp-local-admin/README.md
@@ -2,7 +2,7 @@
 
 Template checkout / checkin scripts for JIT admin access to a standalone **VMware ESXi** host. The same JIT account works for **either the host web UI or SSH** — the script creates the account with shell access enabled (`shellAccess=true`), so it can be used both ways. SSH is only usable if the host's SSH service is enabled (it is disabled by default on ESXi). Adapt for your environment — common customer adjustments include changing the JIT account naming convention, scoping the role grant to a non-root inventory object, or replacing the Administrator role with a custom least-privilege role.
 
-On checkout, an ephemeral local account is created on the host and granted the Administrator role at the root inventory object. The account name is the requestor's email local part — `clint.pollock@example.com` becomes `clint.pollock` — so the audit trail on the ESXi host names the actual person, not a synthetic JIT identifier. The requestor receives the host UI URL, an SSH command, and the ephemeral sign-in credentials. On checkin, the role assignment is removed and the account is deleted. All API calls go to the vSphere SOAP endpoint at `https://<host>/sdk` — no SSH, no agent, no extra infrastructure on the broker side.
+On checkout, an ephemeral local account is created on the host and granted the Administrator role at the root inventory object. The account name is the requestor's email local part — `jane.doe@example.com` becomes `jane.doe` — so the audit trail on the ESXi host names the actual person, not a synthetic JIT identifier. The requestor receives the host UI URL, an SSH command, and the ephemeral sign-in credentials. On checkin, the role assignment is removed and the account is deleted. All API calls go to the vSphere SOAP endpoint at `https://<host>/sdk` — no SSH, no agent, no extra infrastructure on the broker side.
 
 > Standalone ESXi only supports JIT via creation of an ephemeral local account — there is no SSO/AD integration on a single host. vCenter (planned) offers other options like SSO group membership and role grants on existing identities.
 
@@ -40,7 +40,7 @@ On checkout, an ephemeral local account is created on the host and granted the A
 
 ### Checkout (`checkout.py`)
 
-1. Derives the JIT account name from `BRITIVE_USER_EMAIL` — the lowercase email local part with anything outside `[a-z0-9._-]` stripped (e.g. `clint.pollock@example.com` → `clint.pollock`).
+1. Derives the JIT account name from `BRITIVE_USER_EMAIL` — the lowercase email local part with anything outside `[a-z0-9._-]` stripped (e.g. `jane.doe@example.com` → `jane.doe`).
 2. Generates an ephemeral sign-in secret (random, 18 chars).
 3. Calls `Login` on `ha-sessionmgr` to authenticate the service account.
 4. Calls `CreateUser` on `ha-localacctmgr` to create the JIT account with `shellAccess=true`. If the account already exists, `UpdateUser` is called instead to refresh the secret. ⚠ **See "Name Collision" below.**
@@ -66,12 +66,12 @@ On checkout, an ephemeral local account is created on the host and granted the A
 
 ## Name Collision
 
-Because the JIT account name is the email local part with no prefix, a checkout for `clint.pollock@example.com` will hit any pre-existing local account named `clint.pollock` on the host — and the script's "AlreadyExists → UpdateUser" path will **overwrite that account's secret** with the ephemeral JIT secret. On checkin, the account will then be deleted.
+Because the JIT account name is the email local part with no prefix, a checkout for `jane.doe@example.com` will hit any pre-existing local account named `jane.doe` on the host — and the script's "AlreadyExists → UpdateUser" path will **overwrite that account's secret** with the ephemeral JIT secret. On checkin, the account will then be deleted.
 
 **This is fine when ESXi local accounts are managed exclusively through Britive.** If the host has manually-created admin accounts that share names with Britive user emails, you have two options:
 
 1. Keep this behavior and ensure manually-created accounts on the host don't share names with Britive user emails.
-2. Reintroduce a small prefix in `jit_username()` (e.g. `b-clint.pollock`) so JIT accounts can never collide with manually-created ones.
+2. Reintroduce a small prefix in `jit_username()` (e.g. `b-jane.doe`) so JIT accounts can never collide with manually-created ones.
 
 ---
 
@@ -142,16 +142,16 @@ If SSH is left disabled, requestors can still use the web UI URL — the SSH com
 export ESXI_HOST="esxi-01.example.com"
 export ESXI_SVC_USER="britive-svc"
 export ESXI_SVC_PASSWORD="<service-account-secret>"
-export BRITIVE_USER_EMAIL="clint.pollock@example.com"
+export BRITIVE_USER_EMAIL="jane.doe@example.com"
 
 python3 checkout.py
 # {"status": "checked_out", "access_url": "https://esxi-01.example.com/ui",
-#  "ssh_command": "ssh clint.pollock@esxi-01.example.com",
-#  "username": "clint.pollock", ...}
+#  "ssh_command": "ssh jane.doe@esxi-01.example.com",
+#  "username": "jane.doe", ...}
 
 # To clean up (uses ESXI_HOST + ESXI_SVC_USER + ESXI_SVC_PASSWORD + BRITIVE_USER_EMAIL from above):
 python3 checkin.py
-# {"status": "revoked", "removed_user": "clint.pollock"}
+# {"status": "revoked", "removed_user": "jane.doe"}
 ```
 
 ---

--- a/VMware/ESXi/permissions/temp-local-admin/checkin.py
+++ b/VMware/ESXi/permissions/temp-local-admin/checkin.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+ESXi JIT Local Admin Checkin — Britive Access Broker
+
+Removes the JIT account that checkout.py created for the requesting user.
+The account name is derived from BRITIVE_USER_EMAIL the same way checkout
+derived it: the lowercase email local part, sanitized to ESXi-safe chars.
+
+All API calls go to the vSphere SOAP endpoint at https://<host>/sdk.
+
+Required environment variables:
+  ESXI_HOST            IP or hostname of the target ESXi host
+  ESXI_SVC_USER        Service account on the host (must hold Administrator)
+  ESXI_SVC_PASSWORD    Service account secret
+  BRITIVE_USER_EMAIL   Requesting user's email (Britive-injected)
+
+Optional:
+  ESXI_VERIFY_TLS      "true" to verify TLS (default: false)
+
+Stdout: JSON with target_host and the removed account.
+Stderr: progress log lines.
+
+Idempotent: removing an account or permission that does not exist is
+treated as success, so a duplicate checkin will not fail.
+"""
+
+import os
+import re
+import sys
+import ssl
+import json
+import urllib.request
+import urllib.error
+
+
+def env_required(name):
+    value = os.environ.get(name)
+    if not value:
+        print(f'[checkin] ERROR: {name} is not set', file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+ESXI_HOST = env_required('ESXI_HOST')
+ESXI_SVC_USER = env_required('ESXI_SVC_USER')
+ESXI_SVC_PASSWORD = env_required('ESXI_SVC_PASSWORD')
+BRITIVE_USER_EMAIL = env_required('BRITIVE_USER_EMAIL')
+VERIFY_TLS = os.environ.get('ESXI_VERIFY_TLS', 'false').lower() == 'true'
+
+
+_ssl_ctx = ssl.create_default_context()
+if not VERIFY_TLS:
+    _ssl_ctx.check_hostname = False
+    _ssl_ctx.verify_mode = ssl.CERT_NONE
+
+
+def jit_username(email):
+    """Mirror checkout.py: email local part, lowercased, ESXi-safe characters only."""
+    local = email.split('@')[0].lower()
+    safe = re.sub(r'[^a-z0-9._-]', '', local)
+    return safe or 'britive-jit-user'
+
+
+def xml_escape(s):
+    return (s.replace('&', '&amp;').replace('<', '&lt;')
+             .replace('>', '&gt;').replace('"', '&quot;')
+             .replace("'", '&apos;'))
+
+
+def soap(cookie, body):
+    req = urllib.request.Request(
+        f'https://{ESXI_HOST}/sdk',
+        data=body.strip().encode('utf-8'),
+        method='POST',
+    )
+    req.add_header('Content-Type', 'text/xml; charset=utf-8')
+    if cookie:
+        req.add_header('Cookie', cookie)
+    try:
+        with urllib.request.urlopen(req, context=_ssl_ctx, timeout=30) as r:
+            return r.read().decode('utf-8'), r.headers.get('Set-Cookie', '')
+    except urllib.error.HTTPError as e:
+        return e.read().decode('utf-8'), ''
+
+
+def esxi_login():
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Login>
+      <urn:_this type="SessionManager">ha-sessionmgr</urn:_this>
+      <urn:userName>{xml_escape(ESXI_SVC_USER)}</urn:userName>
+      <urn:password>{xml_escape(ESXI_SVC_PASSWORD)}</urn:password>
+    </urn:Login>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, cookie = soap(None, body)
+    if 'InvalidLogin' in content or ('Fault' in content and 'LoginResponse' not in content):
+        raise RuntimeError(f'ESXi login failed: {content[:300]}')
+    return cookie
+
+
+def esxi_remove_permission(cookie, username):
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:RemoveEntityPermission>
+      <urn:_this type="AuthorizationManager">ha-authmgr</urn:_this>
+      <urn:entity type="Folder">ha-folder-root</urn:entity>
+      <urn:user>{xml_escape(username)}</urn:user>
+      <urn:isGroup>false</urn:isGroup>
+    </urn:RemoveEntityPermission>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, _ = soap(cookie, body)
+    if 'Fault' in content and 'NotFound' not in content:
+        print(f'[checkin] WARN removing permission for {username}: {content[:200]}', file=sys.stderr)
+
+
+def esxi_remove_user(cookie, username):
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:RemoveUser>
+      <urn:_this type="HostLocalAccountManager">ha-localacctmgr</urn:_this>
+      <urn:userName>{xml_escape(username)}</urn:userName>
+    </urn:RemoveUser>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, _ = soap(cookie, body)
+    if 'Fault' in content and 'NotFound' not in content and 'UserNotFound' not in content:
+        print(f'[checkin] WARN removing user {username}: {content[:200]}', file=sys.stderr)
+
+
+def esxi_logout(cookie):
+    try:
+        soap(cookie, '''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Logout><urn:_this type="SessionManager">ha-sessionmgr</urn:_this></urn:Logout>
+  </soapenv:Body>
+</soapenv:Envelope>''')
+    except Exception:
+        pass
+
+
+def main():
+    jit_user = jit_username(BRITIVE_USER_EMAIL)
+
+    print(f'[checkin] Connecting to ESXi {ESXI_HOST}', file=sys.stderr)
+    cookie = esxi_login()
+    try:
+        print(f'[checkin] Removing {jit_user}', file=sys.stderr)
+        esxi_remove_permission(cookie, jit_user)
+        esxi_remove_user(cookie, jit_user)
+    finally:
+        esxi_logout(cookie)
+
+    print(f'[checkin] Done — {jit_user} removed', file=sys.stderr)
+    result = {
+        'status': 'revoked',
+        'target_host': ESXI_HOST,
+        'removed_user': jit_user,
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as e:
+        print(f'[checkin] ERROR: {e}', file=sys.stderr)
+        sys.exit(1)

--- a/VMware/ESXi/permissions/temp-local-admin/checkout.py
+++ b/VMware/ESXi/permissions/temp-local-admin/checkout.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+ESXi JIT Local Admin Checkout — Britive Access Broker
+
+Creates an ephemeral local account on a standalone ESXi host, grants the
+Administrator role at the root, and returns the host UI URL, an SSH
+command, and the temporary credentials. The JIT account exists only
+until checkin removes it.
+
+The JIT account name is the requestor's email local part — e.g.
+clint.pollock@example.com becomes "clint.pollock". The same account
+works for both the host web UI and SSH (created with shellAccess=true).
+
+All API calls go to the vSphere SOAP endpoint at https://<host>/sdk.
+
+Required environment variables:
+  ESXI_HOST            IP or hostname of the target ESXi host
+  ESXI_SVC_USER        Service account on the host (must hold Administrator)
+  ESXI_SVC_PASSWORD    Service account secret
+  BRITIVE_USER_EMAIL   Requesting user's email (Britive-injected)
+
+Optional:
+  ESXI_VERIFY_TLS      "true" to verify TLS (default: false — most ESXi hosts use self-signed certs)
+
+Stdout: JSON with target_host, access_url, ssh_command, username, password.
+Stderr: progress log lines.
+"""
+
+import os
+import re
+import sys
+import ssl
+import json
+import random
+import string
+import urllib.request
+import urllib.error
+
+
+def env_required(name):
+    value = os.environ.get(name)
+    if not value:
+        print(f'[checkout] ERROR: {name} is not set', file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+ESXI_HOST = env_required('ESXI_HOST')
+ESXI_SVC_USER = env_required('ESXI_SVC_USER')
+ESXI_SVC_PASSWORD = env_required('ESXI_SVC_PASSWORD')
+BRITIVE_USER_EMAIL = env_required('BRITIVE_USER_EMAIL')
+VERIFY_TLS = os.environ.get('ESXI_VERIFY_TLS', 'false').lower() == 'true'
+
+
+_ssl_ctx = ssl.create_default_context()
+if not VERIFY_TLS:
+    _ssl_ctx.check_hostname = False
+    _ssl_ctx.verify_mode = ssl.CERT_NONE
+
+
+def random_password(length=18):
+    chars = string.ascii_letters + string.digits + '!@#$%^&*'
+    return ''.join(random.SystemRandom().choice(chars) for _ in range(length))
+
+
+def jit_username(email):
+    """Use the email local part as the local account name, sanitized to ESXi-safe characters."""
+    local = email.split('@')[0].lower()
+    safe = re.sub(r'[^a-z0-9._-]', '', local)
+    return safe or 'britive-jit-user'
+
+
+def xml_escape(s):
+    return (s.replace('&', '&amp;').replace('<', '&lt;')
+             .replace('>', '&gt;').replace('"', '&quot;')
+             .replace("'", '&apos;'))
+
+
+def soap(cookie, body):
+    req = urllib.request.Request(
+        f'https://{ESXI_HOST}/sdk',
+        data=body.strip().encode('utf-8'),
+        method='POST',
+    )
+    req.add_header('Content-Type', 'text/xml; charset=utf-8')
+    if cookie:
+        req.add_header('Cookie', cookie)
+    try:
+        with urllib.request.urlopen(req, context=_ssl_ctx, timeout=30) as r:
+            return r.read().decode('utf-8'), r.headers.get('Set-Cookie', '')
+    except urllib.error.HTTPError as e:
+        return e.read().decode('utf-8'), ''
+
+
+def esxi_login():
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Login>
+      <urn:_this type="SessionManager">ha-sessionmgr</urn:_this>
+      <urn:userName>{xml_escape(ESXI_SVC_USER)}</urn:userName>
+      <urn:password>{xml_escape(ESXI_SVC_PASSWORD)}</urn:password>
+    </urn:Login>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, cookie = soap(None, body)
+    if 'InvalidLogin' in content or ('Fault' in content and 'LoginResponse' not in content):
+        raise RuntimeError(f'ESXi login failed: {content[:300]}')
+    return cookie
+
+
+def esxi_create_user(cookie, username, password, description):
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+  xmlns:urn="urn:vim25" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <urn:CreateUser>
+      <urn:_this type="HostLocalAccountManager">ha-localacctmgr</urn:_this>
+      <urn:user xsi:type="urn:HostPosixAccountSpec">
+        <urn:id>{xml_escape(username)}</urn:id>
+        <urn:password>{xml_escape(password)}</urn:password>
+        <urn:description>{xml_escape(description)}</urn:description>
+        <urn:shellAccess>true</urn:shellAccess>
+      </urn:user>
+    </urn:CreateUser>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, _ = soap(cookie, body)
+    if 'Fault' in content:
+        if 'AlreadyExists' in content:
+            print(f'[checkout] User {username} exists — updating password', file=sys.stderr)
+            esxi_update_user(cookie, username, password)
+        else:
+            raise RuntimeError(f'CreateUser failed: {content[:300]}')
+
+
+def esxi_update_user(cookie, username, password):
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+  xmlns:urn="urn:vim25" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <urn:UpdateUser>
+      <urn:_this type="HostLocalAccountManager">ha-localacctmgr</urn:_this>
+      <urn:user xsi:type="urn:HostPosixAccountSpec">
+        <urn:id>{xml_escape(username)}</urn:id>
+        <urn:password>{xml_escape(password)}</urn:password>
+      </urn:user>
+    </urn:UpdateUser>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, _ = soap(cookie, body)
+    if 'Fault' in content:
+        raise RuntimeError(f'UpdateUser failed: {content[:300]}')
+
+
+def esxi_assign_admin(cookie, username):
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:SetEntityPermissions>
+      <urn:_this type="AuthorizationManager">ha-authmgr</urn:_this>
+      <urn:entity type="Folder">ha-folder-root</urn:entity>
+      <urn:permission>
+        <urn:principal>{xml_escape(username)}</urn:principal>
+        <urn:group>false</urn:group>
+        <urn:roleId>-1</urn:roleId>
+        <urn:propagate>true</urn:propagate>
+      </urn:permission>
+    </urn:SetEntityPermissions>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, _ = soap(cookie, body)
+    if 'Fault' in content:
+        raise RuntimeError(f'SetEntityPermissions failed: {content[:300]}')
+
+
+def esxi_logout(cookie):
+    try:
+        soap(cookie, '''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Logout><urn:_this type="SessionManager">ha-sessionmgr</urn:_this></urn:Logout>
+  </soapenv:Body>
+</soapenv:Envelope>''')
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Optional extension: enable the SSH service on the host at checkout time.
+#
+# UNTESTED in this template. The JIT account is already created with
+# shellAccess=true, so SSH will work once the host's TSM-SSH service is
+# running. SSH is disabled by default on ESXi. To have checkout start it
+# automatically, uncomment esxi_start_ssh_service() below and the call
+# site in main(), and gate it with the ESXI_ENABLE_SSH env var (default
+# false).
+#
+# Caveats:
+#   - The service account must hold Host.Config.Settings in addition to
+#     the user/permission privileges it already needs.
+#   - The HostServiceSystem MOID 'serviceSystem' is the standard for
+#     standalone ESXi but verify against your host before relying on it.
+#   - Consider whether checkin should put SSH back to its prior state
+#     (read it before starting, persist somewhere, stop on checkin if it
+#     was off). Not modeled here.
+#
+# def esxi_start_ssh_service(cookie):
+#     body = '''<?xml version="1.0" encoding="UTF-8"?>
+# <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+#   <soapenv:Body>
+#     <urn:StartService>
+#       <urn:_this type="HostServiceSystem">serviceSystem</urn:_this>
+#       <urn:id>TSM-SSH</urn:id>
+#     </urn:StartService>
+#   </soapenv:Body>
+# </soapenv:Envelope>'''
+#     content, _ = soap(cookie, body)
+#     if 'Fault' in content and 'AlreadyRunning' not in content:
+#         raise RuntimeError(f'StartService(TSM-SSH) failed: {content[:300]}')
+# ---------------------------------------------------------------------------
+
+
+def main():
+    jit_user = jit_username(BRITIVE_USER_EMAIL)
+    jit_pass = random_password()
+    access_url = f'https://{ESXI_HOST}/ui'
+
+    print(f'[checkout] Connecting to ESXi {ESXI_HOST}', file=sys.stderr)
+    cookie = esxi_login()
+    try:
+        print(f'[checkout] Creating JIT user {jit_user}', file=sys.stderr)
+        esxi_create_user(cookie, jit_user, jit_pass,
+                         f'Britive JIT — {BRITIVE_USER_EMAIL}')
+        esxi_assign_admin(cookie, jit_user)
+        # if os.environ.get('ESXI_ENABLE_SSH', 'false').lower() == 'true':
+        #     esxi_start_ssh_service(cookie)
+    finally:
+        esxi_logout(cookie)
+    print(f'[checkout] {jit_user} created with Administrator role', file=sys.stderr)
+
+    result = {
+        'status': 'checked_out',
+        'target_host': ESXI_HOST,
+        'access_url': access_url,
+        'ssh_command': f'ssh {jit_user}@{ESXI_HOST}',
+        'username': jit_user,
+        'password': jit_pass,
+        'note': (f'Open {access_url} and sign in with the credentials above, '
+                 f'or use SSH if the SSH service is enabled on the host.'),
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as e:
+        print(f'[checkout] ERROR: {e}', file=sys.stderr)
+        sys.exit(1)

--- a/VMware/ESXi/permissions/temp-local-admin/checkout.py
+++ b/VMware/ESXi/permissions/temp-local-admin/checkout.py
@@ -8,7 +8,7 @@ command, and the temporary credentials. The JIT account exists only
 until checkin removes it.
 
 The JIT account name is the requestor's email local part — e.g.
-clint.pollock@example.com becomes "clint.pollock". The same account
+jane.doe@example.com becomes "jane.doe". The same account
 works for both the host web UI and SSH (created with shellAccess=true).
 
 All API calls go to the vSphere SOAP endpoint at https://<host>/sdk.

--- a/VMware/ESXi/rotate/README.md
+++ b/VMware/ESXi/rotate/README.md
@@ -1,0 +1,69 @@
+# rotate
+
+Template script that rotates an existing local account on a standalone **VMware ESXi** host via the vSphere SOAP API at `https://<host>/sdk`. The account itself is not created or removed — only its stored secret is updated.
+
+Adapt for your environment — common customer adjustments include batching across multiple hosts, post-rotation hooks (e.g. push the new secret to a vault), or coordinating rotations with maintenance windows.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `rotate-esxi-account.py` | Rotate one local account on a single ESXi host |
+
+---
+
+## Environment Variables
+
+### Required
+
+| Variable | Description |
+| --- | --- |
+| `ESXI_HOST` | IP or hostname of the target ESXi host |
+| `ESXI_SVC_USER` | Service account on the host (must hold the Administrator role) |
+| `ESXI_SVC_PASSWORD` | Service account secret |
+| `ESXI_TARGET_USER` | Local account to rotate |
+| `ESXI_NEW_PASSWORD` | New secret to set on the target account |
+
+### Optional
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ESXI_VERIFY_TLS` | `false` | Set `true` to verify TLS — most standalone ESXi hosts use self-signed certs |
+
+---
+
+## How It Works
+
+Calls `Login` on `ha-sessionmgr`, then `UpdateUser` on `ha-localacctmgr` with the target account's `id` and the new secret, then `Logout`. Exits `0` on success, `1` on any failure. Secrets are never written to stdout or logs.
+
+---
+
+## Setup
+
+ESXi service-account setup, broker requirements, and Britive Platform setup are the same as for [`../permissions/temp-local-admin/`](../permissions/temp-local-admin/README.md#esxi-host-setup) — register `rotate-esxi-account.py` as the rotation script on the resource type and mark `ESXI_SVC_PASSWORD` and `ESXI_NEW_PASSWORD` as **sensitive**.
+
+---
+
+## Example
+
+```sh
+export ESXI_HOST="esxi-01.example.com"
+export ESXI_SVC_USER="britive-svc"
+export ESXI_SVC_PASSWORD="<service-account-secret>"
+export ESXI_TARGET_USER="root"
+export ESXI_NEW_PASSWORD="<new-secret>"
+
+python3 rotate-esxi-account.py
+# [rotate] Rotating secret for root
+# [rotate] Secret rotated successfully for root
+```
+
+---
+
+## Notes
+
+- The new secret is sent to the host inside the encrypted HTTPS session — never over plain text.
+- TLS verification defaults off because most standalone ESXi hosts use self-signed certs. Set `ESXI_VERIFY_TLS=true` once you've installed a CA-trusted cert on the host.
+- ESXi enforces password complexity rules via PAM. If `UpdateUser` fails with a complexity-related fault, generate a stronger secret and retry.

--- a/VMware/ESXi/rotate/rotate-esxi-account.py
+++ b/VMware/ESXi/rotate/rotate-esxi-account.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+ESXi Local Account Rotation — Britive Access Broker
+
+Rotates an existing local account on a standalone ESXi host via the
+vSphere SOAP API at https://<host>/sdk. The account itself is not
+created or removed — only its stored secret is updated.
+
+Required environment variables:
+  ESXI_HOST            IP or hostname of the target ESXi host
+  ESXI_SVC_USER        Service account on the host (must hold Administrator)
+  ESXI_SVC_PASSWORD    Service account secret
+  ESXI_TARGET_USER     Local account whose secret will be rotated
+  ESXI_NEW_PASSWORD    New secret to set on the target account
+
+Optional:
+  ESXI_VERIFY_TLS      "true" to verify TLS (default: false)
+
+Stderr: progress log lines. Exit code 0 on success, 1 on any failure.
+Secrets are never written to stdout or logs.
+"""
+
+import os
+import sys
+import ssl
+import urllib.request
+import urllib.error
+
+
+def env_required(name):
+    value = os.environ.get(name)
+    if not value:
+        print(f'[rotate] ERROR: {name} is not set', file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+ESXI_HOST = env_required('ESXI_HOST')
+ESXI_SVC_USER = env_required('ESXI_SVC_USER')
+ESXI_SVC_PASSWORD = env_required('ESXI_SVC_PASSWORD')
+TARGET_USER = env_required('ESXI_TARGET_USER')
+NEW_PASSWORD = env_required('ESXI_NEW_PASSWORD')
+VERIFY_TLS = os.environ.get('ESXI_VERIFY_TLS', 'false').lower() == 'true'
+
+
+_ssl_ctx = ssl.create_default_context()
+if not VERIFY_TLS:
+    _ssl_ctx.check_hostname = False
+    _ssl_ctx.verify_mode = ssl.CERT_NONE
+
+
+def xml_escape(s):
+    return (s.replace('&', '&amp;').replace('<', '&lt;')
+             .replace('>', '&gt;').replace('"', '&quot;')
+             .replace("'", '&apos;'))
+
+
+def soap(cookie, body):
+    req = urllib.request.Request(
+        f'https://{ESXI_HOST}/sdk',
+        data=body.strip().encode('utf-8'),
+        method='POST',
+    )
+    req.add_header('Content-Type', 'text/xml; charset=utf-8')
+    if cookie:
+        req.add_header('Cookie', cookie)
+    try:
+        with urllib.request.urlopen(req, context=_ssl_ctx, timeout=30) as r:
+            return r.read().decode('utf-8'), r.headers.get('Set-Cookie', '')
+    except urllib.error.HTTPError as e:
+        return e.read().decode('utf-8'), ''
+
+
+def esxi_login():
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Login>
+      <urn:_this type="SessionManager">ha-sessionmgr</urn:_this>
+      <urn:userName>{xml_escape(ESXI_SVC_USER)}</urn:userName>
+      <urn:password>{xml_escape(ESXI_SVC_PASSWORD)}</urn:password>
+    </urn:Login>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, cookie = soap(None, body)
+    if 'InvalidLogin' in content or ('Fault' in content and 'LoginResponse' not in content):
+        raise RuntimeError(f'ESXi login failed: {content[:300]}')
+    return cookie
+
+
+def esxi_update_password(cookie, username, new_password):
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+  xmlns:urn="urn:vim25" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Body>
+    <urn:UpdateUser>
+      <urn:_this type="HostLocalAccountManager">ha-localacctmgr</urn:_this>
+      <urn:user xsi:type="urn:HostPosixAccountSpec">
+        <urn:id>{xml_escape(username)}</urn:id>
+        <urn:password>{xml_escape(new_password)}</urn:password>
+      </urn:user>
+    </urn:UpdateUser>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, _ = soap(cookie, body)
+    if 'Fault' in content:
+        raise RuntimeError(f'UpdateUser failed: {content[:300]}')
+
+
+def esxi_logout(cookie):
+    try:
+        soap(cookie, '''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Logout><urn:_this type="SessionManager">ha-sessionmgr</urn:_this></urn:Logout>
+  </soapenv:Body>
+</soapenv:Envelope>''')
+    except Exception:
+        pass
+
+
+def main():
+    print(f'[rotate] Connecting to ESXi {ESXI_HOST}', file=sys.stderr)
+    cookie = esxi_login()
+    try:
+        print(f'[rotate] Rotating secret for {TARGET_USER}', file=sys.stderr)
+        esxi_update_password(cookie, TARGET_USER, NEW_PASSWORD)
+    finally:
+        esxi_logout(cookie)
+    print(f'[rotate] Secret rotated successfully for {TARGET_USER}', file=sys.stderr)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as e:
+        print(f'[rotate] ERROR: {e}', file=sys.stderr)
+        sys.exit(1)

--- a/VMware/ESXi/scans/README.md
+++ b/VMware/ESXi/scans/README.md
@@ -1,0 +1,96 @@
+# scans
+
+Template script that discovers local accounts and groups on a standalone **VMware ESXi** host via the vSphere SOAP API and writes a Britive Resource Manager scan report so Britive's identity inventory stays current.
+
+Adapt for your environment — common customer adjustments include filtering accounts by prefix, adding custom attributes, or extending the report with permission assignments pulled from `AuthorizationManager`.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `scan-esxi-users.py` | Enumerate local accounts and groups; write a Britive Resource Manager JSON report |
+
+---
+
+## Environment Variables
+
+### Required
+
+| Variable | Description |
+| --- | --- |
+| `ESXI_HOST` | IP or hostname of the target ESXi host |
+| `ESXI_SVC_USER` | Service account on the host (must hold the Administrator role) |
+| `ESXI_SVC_PASSWORD` | Service account secret |
+| `BROKER_INJECTED_SCAN_OUTPUT_PATH` | Output file path — auto-injected by Britive at scan time |
+
+### Optional
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ESXI_VERIFY_TLS` | `false` | Set `true` to verify TLS — most standalone ESXi hosts use self-signed certs |
+
+---
+
+## How It Works
+
+1. Calls `Login` on `ha-sessionmgr` to authenticate the service account.
+2. Calls `RetrieveUserGroups` on `ha-user-directory` twice — once with `findUsers=true`, once with `findGroups=true`.
+3. Parses each `<returnval>` block for `principal`, `fullName`, `shellAccess`, `id`.
+4. Builds a Britive Resource Manager output document and writes it to `BROKER_INJECTED_SCAN_OUTPUT_PATH`.
+5. On any failure, writes a document with empty `data` arrays and the failure recorded in `metadata.scan_errors`, then exits `1`.
+
+---
+
+## Output Format
+
+The script writes a JSON document with the shape Britive's Resource Manager expects:
+
+```
+{
+  "data": {
+    "identities": [...],         # one entry per local account on the host
+    "groups": [...],             # one entry per local group on the host
+    "permissions": [],           # empty — defined in the resource type, not from scan
+    "permission_mapping": []     # empty — defined in the resource type, not from scan
+  },
+  "metadata": {
+    "resource_id": "<ESXI_HOST>",
+    "resource_type": "ESXi",
+    "scan_time": "<ISO-8601 UTC>",
+    "scan_details": "ESXi scan completed. Users: N, Groups: N",
+    "scan_errors": "",
+    "attribute_resolution": {
+      "group_membership": "id",
+      "permission_mapping": "id"
+    }
+  }
+}
+```
+
+Each identity entry includes `id`, `name`, `type`, `description`, `created_on`, `is_active`, and an `attributes` block with `email`, `first_name`, `last_name`, `shell_access`, `posix_id`. Each group entry includes `id`, `name`, `type`, `description`, `created_on`, `is_active`, `members`, `attributes`.
+
+> **`permissions` and `permission_mapping` are empty by design.** Britive checkout permissions for this resource type are defined in the resource type itself, not derived from this scan. The scan exists to keep the identity inventory current.
+
+---
+
+## Setup
+
+ESXi service-account setup, broker requirements, and Britive Platform setup are the same as for [`../permissions/temp-local-admin/`](../permissions/temp-local-admin/README.md#esxi-host-setup) — register `scan-esxi-users.py` as the scan script on the resource type. `BROKER_INJECTED_SCAN_OUTPUT_PATH` is supplied automatically by Britive — do not configure it.
+
+---
+
+## Example
+
+```sh
+export ESXI_HOST="esxi-01.example.com"
+export ESXI_SVC_USER="britive-svc"
+export ESXI_SVC_PASSWORD="<service-account-secret>"
+export BROKER_INJECTED_SCAN_OUTPUT_PATH="/tmp/esxi-scan.json"
+
+python3 scan-esxi-users.py
+# [scan] Found 3 user(s)
+# [scan] Found 1 group(s)
+# [scan] Output written to /tmp/esxi-scan.json
+```

--- a/VMware/ESXi/scans/scan-esxi-users.py
+++ b/VMware/ESXi/scans/scan-esxi-users.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+ESXi IAM Scan — Britive Access Broker
+
+Discovers local users and groups on a standalone ESXi host via the
+vSphere SOAP API and writes a Britive Resource Manager scan report
+to BROKER_INJECTED_SCAN_OUTPUT_PATH.
+
+Required environment variables:
+  ESXI_HOST                          IP or hostname of the target ESXi host
+  ESXI_SVC_USER                      Service account on the host (must hold Administrator)
+  ESXI_SVC_PASSWORD                  Service account password
+  BROKER_INJECTED_SCAN_OUTPUT_PATH   Output file path (auto-injected by Britive)
+
+Optional:
+  ESXI_VERIFY_TLS                    "true" to verify TLS (default: false)
+
+Output: JSON document at BROKER_INJECTED_SCAN_OUTPUT_PATH with the
+shape Britive's Resource Manager expects:
+  {
+    "data": {"identities": [...], "groups": [...], "permissions": [], "permission_mapping": []},
+    "metadata": {...}
+  }
+
+Permissions are defined in the resource type, not from this scan, so
+the permissions and permission_mapping arrays are intentionally empty.
+"""
+
+import os
+import re
+import sys
+import ssl
+import json
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+
+
+def env_required(name):
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f'{name} is not set')
+    return value
+
+
+VERIFY_TLS = os.environ.get('ESXI_VERIFY_TLS', 'false').lower() == 'true'
+
+_ssl_ctx = ssl.create_default_context()
+if not VERIFY_TLS:
+    _ssl_ctx.check_hostname = False
+    _ssl_ctx.verify_mode = ssl.CERT_NONE
+
+
+def xml_escape(s):
+    return (s.replace('&', '&amp;').replace('<', '&lt;')
+             .replace('>', '&gt;').replace('"', '&quot;')
+             .replace("'", '&apos;'))
+
+
+def soap(host, cookie, body):
+    req = urllib.request.Request(
+        f'https://{host}/sdk',
+        data=body.strip().encode('utf-8'),
+        method='POST',
+    )
+    req.add_header('Content-Type', 'text/xml; charset=utf-8')
+    if cookie:
+        req.add_header('Cookie', cookie)
+    try:
+        with urllib.request.urlopen(req, context=_ssl_ctx, timeout=30) as r:
+            return r.read().decode('utf-8'), r.headers.get('Set-Cookie', '')
+    except urllib.error.HTTPError as e:
+        return e.read().decode('utf-8'), ''
+
+
+def esxi_login(host, user, password):
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Login>
+      <urn:_this type="SessionManager">ha-sessionmgr</urn:_this>
+      <urn:userName>{xml_escape(user)}</urn:userName>
+      <urn:password>{xml_escape(password)}</urn:password>
+    </urn:Login>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, cookie = soap(host, None, body)
+    if 'InvalidLogin' in content or ('Fault' in content and 'LoginResponse' not in content):
+        raise RuntimeError(f'ESXi login failed: {content[:300]}')
+    return cookie
+
+
+def esxi_logout(host, cookie):
+    try:
+        soap(host, cookie, '''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Logout><urn:_this type="SessionManager">ha-sessionmgr</urn:_this></urn:Logout>
+  </soapenv:Body>
+</soapenv:Envelope>''')
+    except Exception:
+        pass
+
+
+def retrieve_user_groups(host, cookie, find_users):
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:RetrieveUserGroups>
+      <urn:_this type="UserDirectory">ha-user-directory</urn:_this>
+      <urn:searchStr></urn:searchStr>
+      <urn:exactMatch>false</urn:exactMatch>
+      <urn:findUsers>{'true' if find_users else 'false'}</urn:findUsers>
+      <urn:findGroups>{'false' if find_users else 'true'}</urn:findGroups>
+    </urn:RetrieveUserGroups>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, _ = soap(host, cookie, body)
+    return content
+
+
+def parse_returnvals(xml_content):
+    results = []
+    blocks = re.findall(r'<returnval[^>]*>(.*?)</returnval>', xml_content, re.DOTALL)
+    for block in blocks:
+        entry = {}
+        for tag in ['principal', 'fullName', 'shellAccess', 'id', 'group', 'roleId']:
+            m = re.search(rf'<{tag}>(.*?)</{tag}>', block)
+            if m:
+                entry[tag] = m.group(1)
+        if entry:
+            results.append(entry)
+    return results
+
+
+def write_output(path, data):
+    os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+
+
+def main():
+    output_path = env_required('BROKER_INJECTED_SCAN_OUTPUT_PATH')
+    host = env_required('ESXI_HOST')
+    svc_user = env_required('ESXI_SVC_USER')
+    svc_password = env_required('ESXI_SVC_PASSWORD')
+
+    now = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    print(f'[scan] Connecting to ESXi {host}', file=sys.stderr)
+
+    cookie = esxi_login(host, svc_user, svc_password)
+    try:
+        user_xml = retrieve_user_groups(host, cookie, find_users=True)
+        user_entries = parse_returnvals(user_xml)
+        identities = []
+        for u in user_entries:
+            principal = u.get('principal', '')
+            if not principal:
+                continue
+            identities.append({
+                'id': principal,
+                'name': principal,
+                'type': 'User',
+                'description': u.get('fullName', 'ESXi local user'),
+                'created_on': now,
+                'is_active': True,
+                'attributes': {
+                    'email': f'{principal}@{host}',
+                    'first_name': u.get('fullName', principal),
+                    'last_name': 'esxi',
+                    'shell_access': u.get('shellAccess', 'false'),
+                    'posix_id': u.get('id', ''),
+                },
+            })
+        print(f'[scan] Found {len(identities)} user(s)', file=sys.stderr)
+
+        group_xml = retrieve_user_groups(host, cookie, find_users=False)
+        group_entries = parse_returnvals(group_xml)
+        groups = []
+        for g in group_entries:
+            principal = g.get('principal', '')
+            if not principal:
+                continue
+            groups.append({
+                'id': principal,
+                'name': principal,
+                'type': 'User group',
+                'description': g.get('fullName', 'ESXi local group'),
+                'created_on': now,
+                'is_active': True,
+                'members': [],
+                'attributes': {
+                    'samaccountname': principal,
+                },
+            })
+        print(f'[scan] Found {len(groups)} group(s)', file=sys.stderr)
+    finally:
+        esxi_logout(host, cookie)
+
+    output = {
+        'data': {
+            'identities': identities,
+            'groups': groups,
+            'permissions': [],
+            'permission_mapping': [],
+        },
+        'metadata': {
+            'resource_id': host,
+            'resource_type': 'ESXi',
+            'scan_time': now,
+            'scan_details': f'ESXi scan completed. Users: {len(identities)}, Groups: {len(groups)}',
+            'scan_errors': '',
+            'attribute_resolution': {
+                'group_membership': 'id',
+                'permission_mapping': 'id',
+            },
+        },
+    }
+    write_output(output_path, output)
+    print(f'[scan] Output written to {output_path}', file=sys.stderr)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as e:
+        print(f'[scan] ERROR: {e}', file=sys.stderr)
+        out = os.environ.get('BROKER_INJECTED_SCAN_OUTPUT_PATH', '')
+        if out:
+            error_output = {
+                'data': {'identities': [], 'groups': [], 'permissions': [], 'permission_mapping': []},
+                'metadata': {
+                    'scan_errors': str(e),
+                    'scan_time': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                },
+            }
+            try:
+                write_output(out, error_output)
+            except Exception:
+                pass
+        sys.exit(1)

--- a/VMware/README.md
+++ b/VMware/README.md
@@ -1,0 +1,24 @@
+# VMware
+
+Template Britive Access Broker scripts for VMware products. All scripts in this directory talk to the target host via the **vSphere SOAP API** at `https://<host>/sdk` — no agent or extra service required on the target.
+
+These are starting points — adapt them for your environment as needed.
+
+---
+
+## Subdirectories
+
+| Directory | Purpose |
+|---|---|
+| [`ESXi/`](ESXi/README.md) | Standalone ESXi hypervisor — JIT local accounts, account rotation, IAM scans |
+| [`vCenter/`](vCenter/README.md) | vCenter Server — JIT role grants on existing SSO/AD identities |
+
+---
+
+## Common Concepts
+
+| Requirement | Detail |
+|---|---|
+| **Network** | TCP 443 from the broker host to each target ESXi/vCenter |
+| **Auth** | A SOAP service account on the host with permission to manage local accounts and roles |
+| **Broker host** | Python 3.8+ with the standard library (no third-party packages required) |

--- a/VMware/vCenter/README.md
+++ b/VMware/vCenter/README.md
@@ -1,0 +1,45 @@
+# VMware vCenter
+
+Template scripts for **VMware vCenter Server** (8.x). Adapt them for your environment as needed.
+
+vCenter has a fundamentally different identity model than standalone ESXi — it does not have a `HostLocalAccountManager`-style SOAP API for creating local accounts on the box. Authentication goes through **vCenter Single Sign-On**, with users coming from either the local SSO domain (`vsphere.local`) or a federated identity source (AD, LDAP, ADFS, OIDC). The realistic JIT pattern is therefore **role grant on an existing identity**, not "create a temp user." See [`permissions/temp-vcenter-admin/`](permissions/temp-vcenter-admin/README.md) for the baseline.
+
+> Why not "elevate to each ESXi through vCenter"? You can — `SetEntityPermissions` works at any inventory level, including individual `HostSystem` objects — but the audit story gets muddier (one role binding per host, propagation flags to manage, scope drift if hosts move datacenters). The simpler "Administrator at vCenter root" pattern covers the common case. Customers needing per-host scoping can adapt the entity MOID in `checkout.py`.
+
+---
+
+## Subdirectories
+
+| Directory | Purpose |
+|---|---|
+| [`permissions/temp-vcenter-admin/`](permissions/temp-vcenter-admin/README.md) | JIT Administrator role grant at the vCenter root for an existing SSO/AD identity |
+
+---
+
+## Target
+
+| Attribute | Value |
+|---|---|
+| **Platform** | VMware vCenter Server |
+| **Tested versions** | vCenter 8.0 |
+| **API** | vSphere SOAP at `https://<vcenter>/sdk` |
+| **Port** | TCP 443 |
+| **Auth** | vCenter SSO (local domain `vsphere.local` or federated AD/LDAP/OIDC) |
+
+---
+
+## Common Prerequisites
+
+- A service account in vCenter SSO with the `Administrator` role at the root, **or** a custom role with at minimum `Permissions.ModifyPermissions` at every entity where you grant or revoke role bindings. Service-account names are usually `<user>@vsphere.local` for local SSO accounts.
+- Outbound TCP 443 from the broker host to vCenter.
+- `python3` 3.8+ on the broker host (standard library only — no third-party packages).
+
+---
+
+## What's Not Here (and Why)
+
+| Pattern | Why deferred |
+|---|---|
+| `rotate/` | Local SSO users do exist (`<user>@vsphere.local`), but rotation needs the SSO Admin API at `/sso-adminserver/sdk/vsphere.local` — a separate endpoint with its own envelope shape. Most customers federate SSO with AD and rotate there, not in vCenter. Add only if you have a real use case. |
+| `scans/` | Walking SSO domain users for Britive's identity inventory is a bigger lift than the ESXi local-account scan — the same SSO Admin API is involved, plus SAML group resolution. Add when needed. |
+| Per-host elevation through vCenter | Solvable but adds complexity (one binding per host, propagation flags, scope drift). The "Administrator at vCenter root" template covers the common case; customize the entity MOID for narrower scopes. |

--- a/VMware/vCenter/permissions/temp-vcenter-admin/README.md
+++ b/VMware/vCenter/permissions/temp-vcenter-admin/README.md
@@ -121,15 +121,15 @@ If your identity source uses sAMAccountName (downlevel logon) rather than UPN/em
 export VCENTER_HOST="vcenter-01.example.com"
 export VCENTER_SVC_USER="britive-svc@vsphere.local"
 export VCENTER_SVC_PASSWORD="<service-account-secret>"
-export BRITIVE_USER_EMAIL="clint.pollock@example.com"
+export BRITIVE_USER_EMAIL="jane.doe@example.com"
 
 python3 checkout.py
 # {"status": "checked_out", "access_url": "https://vcenter-01.example.com/ui",
-#  "principal": "clint.pollock@example.com", "role_id": -1, "entity": "group-d1", ...}
+#  "principal": "jane.doe@example.com", "role_id": -1, "entity": "group-d1", ...}
 
 # To clean up (uses VCENTER_HOST + VCENTER_SVC_USER + VCENTER_SVC_PASSWORD + BRITIVE_USER_EMAIL from above):
 python3 checkin.py
-# {"status": "revoked", "principal": "clint.pollock@example.com", "entity": "group-d1"}
+# {"status": "revoked", "principal": "jane.doe@example.com", "entity": "group-d1"}
 ```
 
 ---

--- a/VMware/vCenter/permissions/temp-vcenter-admin/README.md
+++ b/VMware/vCenter/permissions/temp-vcenter-admin/README.md
@@ -1,0 +1,142 @@
+# temp-vcenter-admin
+
+Template checkout / checkin scripts for JIT Administrator access to a **VMware vCenter Server**. Unlike the standalone ESXi pattern, no local account is created — vCenter authenticates through SSO, so this template grants the **Administrator role at the vCenter root folder** to the requestor's existing SSO/AD identity, then revokes the grant on checkin. Adapt for your environment — common customer adjustments include scoping the role grant to a non-root inventory object (a specific datacenter, cluster, or host), substituting a custom least-privilege role for Administrator, or transforming the requestor's email into a different principal format (e.g. AD downlevel `EXAMPLE\jdoe`).
+
+The requestor signs in to vCenter with their **usual identity** — there are no ephemeral credentials to hand back. The scripts call the vSphere SOAP API at `https://<vcenter>/sdk` only.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `checkout.py` | Grant Administrator role at the vCenter root folder to the requestor's principal |
+| `checkin.py` | Remove the role binding for that principal at the same entity |
+
+---
+
+## Environment Variables
+
+### Required (set by Britive)
+
+| Variable | Description |
+| --- | --- |
+| `VCENTER_HOST` | IP or hostname of the vCenter Server |
+| `VCENTER_SVC_USER` | Service account username (e.g. `britive-svc@vsphere.local`) |
+| `VCENTER_SVC_PASSWORD` | Service account secret |
+| `BRITIVE_USER_EMAIL` | Britive user email — used as the principal to elevate by default |
+
+### Optional (with defaults)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `VCENTER_PRINCIPAL` | `BRITIVE_USER_EMAIL` | Override the principal that gets elevated. Use this if your identity source format is not email/UPN — e.g. set to `EXAMPLE\jdoe` for AD downlevel logon names |
+| `VCENTER_ROLE_ID` | `-1` | Role ID to grant (`-1` = built-in Administrator). For least-privilege, create a custom role in vCenter and set its ID here |
+| `VCENTER_ROOT_MOID` | `group-d1` | Inventory entity to grant the role at. Default is the vCenter root folder; change to a `Datacenter`, `ClusterComputeResource`, or `HostSystem` MOID to scope narrower |
+| `VCENTER_PROPAGATE` | `true` | Whether the role propagates to children of the entity |
+| `VCENTER_VERIFY_TLS` | `false` | Set `true` to verify TLS — vCenter installs often use the built-in self-signed cert |
+
+---
+
+## How It Works
+
+### Checkout (`checkout.py`)
+
+1. Resolves the principal: `VCENTER_PRINCIPAL` if set, otherwise `BRITIVE_USER_EMAIL`.
+2. Calls `Login` on `SessionManager` to authenticate the service account.
+3. Calls `SetEntityPermissions` on `AuthorizationManager` with the principal, the target entity (`VCENTER_ROOT_MOID`), the role (`VCENTER_ROLE_ID`), and propagation flag.
+4. Calls `Logout` and returns:
+   ```json
+   {"status": "checked_out", "target_host": "<vcenter>", "access_url": "https://<vcenter>/ui", "principal": "<elevated-principal>", "role_id": -1, "entity": "group-d1", "note": "Sign in to vCenter at the URL above with your usual identity. The Administrator role is granted until checkin."}
+   ```
+
+### Checkin (`checkin.py`)
+
+1. Resolves the principal the same way checkout did.
+2. Calls `Login` on `SessionManager`.
+3. Calls `RemoveEntityPermission` on `AuthorizationManager` for the principal at the same entity.
+4. Faults of type `NotFound` are treated as success — checkin is idempotent.
+5. Calls `Logout` and returns:
+   ```json
+   {"status": "revoked", "target_host": "<vcenter>", "principal": "<principal>", "entity": "group-d1"}
+   ```
+
+---
+
+## vCenter Setup
+
+### 1. Create the service account
+
+In **Administration → Single Sign On → Users and Groups**:
+
+1. Select the `vsphere.local` domain.
+2. Create the service account (e.g. `britive-svc`).
+
+### 2. Grant the service account permission to manage role bindings
+
+In **Administration → Access Control → Global Permissions**:
+
+1. **+ Add** → select the service account.
+2. Assign a role with at minimum `Permissions.ModifyPermissions`. The built-in **Administrator** role works; for least privilege, create a custom role with only that single privilege.
+3. Set scope to the entity tree the broker will manage role bindings on (typically the root, with **Propagate to children** checked).
+
+### 3. (Federated identity sources)
+
+If your vCenter is federated with AD / LDAP / OIDC, the Britive user's email must map to a recognized principal in that identity source. Confirm by signing in to vCenter manually as the requestor — if that works, `SetEntityPermissions` will accept the same principal.
+
+If your identity source uses sAMAccountName (downlevel logon) rather than UPN/email, set `VCENTER_PRINCIPAL` to the right format on the resource type — e.g. `EXAMPLE\jdoe` instead of `jdoe@example.com`.
+
+### 4. Network requirements
+
+- TCP 443 from the broker host to vCenter (SOAP API at `/sdk`).
+
+---
+
+## Broker Container Requirements
+
+- `python3` 3.8+ (standard library only — no third-party packages)
+- Outbound TCP 443 to vCenter
+
+---
+
+## Britive Platform Setup
+
+1. Create a broker pool connected to your broker deployment.
+2. Create a `vCenter` resource type with `checkout.py` as the checkout script and `checkin.py` as the checkin script.
+3. Set the following script parameters on the permission:
+
+   **Always required:** `VCENTER_HOST`, `VCENTER_SVC_USER`, `VCENTER_SVC_PASSWORD`
+
+   **Optional:** `VCENTER_PRINCIPAL`, `VCENTER_ROLE_ID`, `VCENTER_ROOT_MOID`, `VCENTER_PROPAGATE`, `VCENTER_VERIFY_TLS`
+
+4. Mark `VCENTER_SVC_PASSWORD` as **sensitive** so it's encrypted at rest and injected securely at runtime.
+5. Set the response template so the requestor sees `{{access_url}}` and `{{note}}` from the checkout output.
+6. Assign users or tags to the profile policy.
+
+---
+
+## Example: Manual Test Run
+
+```sh
+export VCENTER_HOST="vcenter-01.example.com"
+export VCENTER_SVC_USER="britive-svc@vsphere.local"
+export VCENTER_SVC_PASSWORD="<service-account-secret>"
+export BRITIVE_USER_EMAIL="clint.pollock@example.com"
+
+python3 checkout.py
+# {"status": "checked_out", "access_url": "https://vcenter-01.example.com/ui",
+#  "principal": "clint.pollock@example.com", "role_id": -1, "entity": "group-d1", ...}
+
+# To clean up (uses VCENTER_HOST + VCENTER_SVC_USER + VCENTER_SVC_PASSWORD + BRITIVE_USER_EMAIL from above):
+python3 checkin.py
+# {"status": "revoked", "principal": "clint.pollock@example.com", "entity": "group-d1"}
+```
+
+---
+
+## Notes
+
+- This template grants the role **at the vCenter root folder** with propagation enabled, which means the requestor inherits Administrator on every datacenter, cluster, host, and VM. To scope tighter, change `VCENTER_ROOT_MOID` to the MOID of the specific entity you want elevated. You can read MOIDs from the vCenter UI URL (e.g. `https://<vcenter>/ui/app/host/host-12`) or via `RetrieveServiceContent` + `PropertyCollector` queries.
+- vCenter does not echo "ephemeral credentials" back like the ESXi template does — the requestor uses their existing identity. The audit trail in vCenter shows the actual person, not a synthetic JIT identifier.
+- If the requestor already has a standing role binding at the same entity, `SetEntityPermissions` will overwrite it. On checkin, only the binding the script created is removed — pre-existing standing access (if any) is not restored.
+- vCenter sessions are by default recorded in `vpxd.log` and the events database. For session recording at the UI level (screen capture / keystrokes), follow the same Bridge + jump-box pattern noted in the ESXi template.

--- a/VMware/vCenter/permissions/temp-vcenter-admin/checkin.py
+++ b/VMware/vCenter/permissions/temp-vcenter-admin/checkin.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+vCenter JIT Admin Checkin — Britive Access Broker
+
+Removes the role binding that checkout.py created for the requesting
+user at the configured entity. The principal is derived from
+BRITIVE_USER_EMAIL (or the explicit VCENTER_PRINCIPAL override) the
+same way checkout derived it.
+
+Required environment variables:
+  VCENTER_HOST          IP or hostname of the vCenter Server
+  VCENTER_SVC_USER      Service account username (e.g. britive-svc@vsphere.local)
+  VCENTER_SVC_PASSWORD  Service account secret
+  BRITIVE_USER_EMAIL    Requesting user's email (Britive-injected) — default principal
+
+Optional:
+  VCENTER_PRINCIPAL     Override the principal to revoke (default: BRITIVE_USER_EMAIL)
+  VCENTER_ROOT_MOID     Inventory entity MOID where the binding was made (default: group-d1)
+  VCENTER_VERIFY_TLS    "true" to verify TLS (default: false)
+
+Stdout: JSON with target_host, principal, entity.
+Stderr: progress log lines.
+
+Idempotent: removing a binding that does not exist is treated as
+success, so a duplicate checkin will not fail.
+"""
+
+import os
+import sys
+import ssl
+import json
+import urllib.request
+import urllib.error
+
+
+def env_required(name):
+    value = os.environ.get(name)
+    if not value:
+        print(f'[checkin] ERROR: {name} is not set', file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+VCENTER_HOST = env_required('VCENTER_HOST')
+VCENTER_SVC_USER = env_required('VCENTER_SVC_USER')
+VCENTER_SVC_PASSWORD = env_required('VCENTER_SVC_PASSWORD')
+BRITIVE_USER_EMAIL = env_required('BRITIVE_USER_EMAIL')
+
+PRINCIPAL = os.environ.get('VCENTER_PRINCIPAL') or BRITIVE_USER_EMAIL
+ROOT_MOID = os.environ.get('VCENTER_ROOT_MOID', 'group-d1')
+VERIFY_TLS = os.environ.get('VCENTER_VERIFY_TLS', 'false').lower() == 'true'
+
+
+_ssl_ctx = ssl.create_default_context()
+if not VERIFY_TLS:
+    _ssl_ctx.check_hostname = False
+    _ssl_ctx.verify_mode = ssl.CERT_NONE
+
+
+def xml_escape(s):
+    return (s.replace('&', '&amp;').replace('<', '&lt;')
+             .replace('>', '&gt;').replace('"', '&quot;')
+             .replace("'", '&apos;'))
+
+
+def soap(cookie, body):
+    req = urllib.request.Request(
+        f'https://{VCENTER_HOST}/sdk',
+        data=body.strip().encode('utf-8'),
+        method='POST',
+    )
+    req.add_header('Content-Type', 'text/xml; charset=utf-8')
+    if cookie:
+        req.add_header('Cookie', cookie)
+    try:
+        with urllib.request.urlopen(req, context=_ssl_ctx, timeout=30) as r:
+            return r.read().decode('utf-8'), r.headers.get('Set-Cookie', '')
+    except urllib.error.HTTPError as e:
+        return e.read().decode('utf-8'), ''
+
+
+def vcenter_login():
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Login>
+      <urn:_this type="SessionManager">SessionManager</urn:_this>
+      <urn:userName>{xml_escape(VCENTER_SVC_USER)}</urn:userName>
+      <urn:password>{xml_escape(VCENTER_SVC_PASSWORD)}</urn:password>
+    </urn:Login>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, cookie = soap(None, body)
+    if 'InvalidLogin' in content or ('Fault' in content and 'LoginResponse' not in content):
+        raise RuntimeError(f'vCenter login failed: {content[:300]}')
+    return cookie
+
+
+def vcenter_remove_role(cookie):
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:RemoveEntityPermission>
+      <urn:_this type="AuthorizationManager">AuthorizationManager</urn:_this>
+      <urn:entity type="Folder">{xml_escape(ROOT_MOID)}</urn:entity>
+      <urn:user>{xml_escape(PRINCIPAL)}</urn:user>
+      <urn:isGroup>false</urn:isGroup>
+    </urn:RemoveEntityPermission>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, _ = soap(cookie, body)
+    if 'Fault' in content and 'NotFound' not in content:
+        print(f'[checkin] WARN removing permission for {PRINCIPAL}: {content[:200]}', file=sys.stderr)
+
+
+def vcenter_logout(cookie):
+    try:
+        soap(cookie, '''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Logout><urn:_this type="SessionManager">SessionManager</urn:_this></urn:Logout>
+  </soapenv:Body>
+</soapenv:Envelope>''')
+    except Exception:
+        pass
+
+
+def main():
+    print(f'[checkin] Connecting to vCenter {VCENTER_HOST}', file=sys.stderr)
+    cookie = vcenter_login()
+    try:
+        print(f'[checkin] Removing role binding for {PRINCIPAL} at {ROOT_MOID}', file=sys.stderr)
+        vcenter_remove_role(cookie)
+    finally:
+        vcenter_logout(cookie)
+
+    print(f'[checkin] Done — binding revoked for {PRINCIPAL}', file=sys.stderr)
+    result = {
+        'status': 'revoked',
+        'target_host': VCENTER_HOST,
+        'principal': PRINCIPAL,
+        'entity': ROOT_MOID,
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as e:
+        print(f'[checkin] ERROR: {e}', file=sys.stderr)
+        sys.exit(1)

--- a/VMware/vCenter/permissions/temp-vcenter-admin/checkout.py
+++ b/VMware/vCenter/permissions/temp-vcenter-admin/checkout.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+vCenter JIT Admin Checkout — Britive Access Broker
+
+Grants a role (default: Administrator) at the vCenter root folder to an
+existing identity (the requestor's SSO/AD principal). No local account
+is created — the requestor signs in to vCenter with their usual
+identity and finds the role granted until checkin.
+
+Required environment variables:
+  VCENTER_HOST          IP or hostname of the vCenter Server
+  VCENTER_SVC_USER      Service account username (e.g. britive-svc@vsphere.local)
+  VCENTER_SVC_PASSWORD  Service account secret
+  BRITIVE_USER_EMAIL    Requesting user's email (Britive-injected) — default principal to elevate
+
+Optional:
+  VCENTER_PRINCIPAL     Override the principal to elevate (default: BRITIVE_USER_EMAIL)
+  VCENTER_ROLE_ID       Role ID to grant (default: -1, built-in Administrator)
+  VCENTER_ROOT_MOID     Inventory entity MOID to grant at (default: group-d1, vCenter root folder)
+  VCENTER_PROPAGATE     "true"/"false" — whether the role propagates to children (default: true)
+  VCENTER_VERIFY_TLS    "true" to verify TLS (default: false)
+
+Stdout: JSON with target_host, access_url, principal, role_id, entity.
+Stderr: progress log lines.
+"""
+
+import os
+import sys
+import ssl
+import json
+import urllib.request
+import urllib.error
+
+
+def env_required(name):
+    value = os.environ.get(name)
+    if not value:
+        print(f'[checkout] ERROR: {name} is not set', file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+VCENTER_HOST = env_required('VCENTER_HOST')
+VCENTER_SVC_USER = env_required('VCENTER_SVC_USER')
+VCENTER_SVC_PASSWORD = env_required('VCENTER_SVC_PASSWORD')
+BRITIVE_USER_EMAIL = env_required('BRITIVE_USER_EMAIL')
+
+PRINCIPAL = os.environ.get('VCENTER_PRINCIPAL') or BRITIVE_USER_EMAIL
+ROLE_ID = int(os.environ.get('VCENTER_ROLE_ID', '-1'))
+ROOT_MOID = os.environ.get('VCENTER_ROOT_MOID', 'group-d1')
+PROPAGATE = os.environ.get('VCENTER_PROPAGATE', 'true').lower() == 'true'
+VERIFY_TLS = os.environ.get('VCENTER_VERIFY_TLS', 'false').lower() == 'true'
+
+
+_ssl_ctx = ssl.create_default_context()
+if not VERIFY_TLS:
+    _ssl_ctx.check_hostname = False
+    _ssl_ctx.verify_mode = ssl.CERT_NONE
+
+
+def xml_escape(s):
+    return (s.replace('&', '&amp;').replace('<', '&lt;')
+             .replace('>', '&gt;').replace('"', '&quot;')
+             .replace("'", '&apos;'))
+
+
+def soap(cookie, body):
+    req = urllib.request.Request(
+        f'https://{VCENTER_HOST}/sdk',
+        data=body.strip().encode('utf-8'),
+        method='POST',
+    )
+    req.add_header('Content-Type', 'text/xml; charset=utf-8')
+    if cookie:
+        req.add_header('Cookie', cookie)
+    try:
+        with urllib.request.urlopen(req, context=_ssl_ctx, timeout=30) as r:
+            return r.read().decode('utf-8'), r.headers.get('Set-Cookie', '')
+    except urllib.error.HTTPError as e:
+        return e.read().decode('utf-8'), ''
+
+
+def vcenter_login():
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Login>
+      <urn:_this type="SessionManager">SessionManager</urn:_this>
+      <urn:userName>{xml_escape(VCENTER_SVC_USER)}</urn:userName>
+      <urn:password>{xml_escape(VCENTER_SVC_PASSWORD)}</urn:password>
+    </urn:Login>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, cookie = soap(None, body)
+    if 'InvalidLogin' in content or ('Fault' in content and 'LoginResponse' not in content):
+        raise RuntimeError(f'vCenter login failed: {content[:300]}')
+    return cookie
+
+
+def vcenter_assign_role(cookie):
+    body = f'''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:SetEntityPermissions>
+      <urn:_this type="AuthorizationManager">AuthorizationManager</urn:_this>
+      <urn:entity type="Folder">{xml_escape(ROOT_MOID)}</urn:entity>
+      <urn:permission>
+        <urn:principal>{xml_escape(PRINCIPAL)}</urn:principal>
+        <urn:group>false</urn:group>
+        <urn:roleId>{ROLE_ID}</urn:roleId>
+        <urn:propagate>{'true' if PROPAGATE else 'false'}</urn:propagate>
+      </urn:permission>
+    </urn:SetEntityPermissions>
+  </soapenv:Body>
+</soapenv:Envelope>'''
+    content, _ = soap(cookie, body)
+    if 'Fault' in content:
+        raise RuntimeError(f'SetEntityPermissions failed: {content[:300]}')
+
+
+def vcenter_logout(cookie):
+    try:
+        soap(cookie, '''<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:Logout><urn:_this type="SessionManager">SessionManager</urn:_this></urn:Logout>
+  </soapenv:Body>
+</soapenv:Envelope>''')
+    except Exception:
+        pass
+
+
+def main():
+    access_url = f'https://{VCENTER_HOST}/ui'
+
+    print(f'[checkout] Connecting to vCenter {VCENTER_HOST}', file=sys.stderr)
+    cookie = vcenter_login()
+    try:
+        print(f'[checkout] Granting role {ROLE_ID} to {PRINCIPAL} at {ROOT_MOID}', file=sys.stderr)
+        vcenter_assign_role(cookie)
+    finally:
+        vcenter_logout(cookie)
+    print(f'[checkout] {PRINCIPAL} elevated', file=sys.stderr)
+
+    result = {
+        'status': 'checked_out',
+        'target_host': VCENTER_HOST,
+        'access_url': access_url,
+        'principal': PRINCIPAL,
+        'role_id': ROLE_ID,
+        'entity': ROOT_MOID,
+        'note': (f'Sign in to vCenter at {access_url} with your usual identity. '
+                 f'The role is granted until checkin.'),
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as e:
+        print(f'[checkout] ERROR: {e}', file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Adds template Britive Access Broker scripts for **VMware ESXi** (standalone) and **vCenter Server** under a new top-level `VMware/` directory. All scripts use the vSphere SOAP API at `https://<host>/sdk` (Python 3.8+, standard library only).

### `VMware/ESXi/`

- **`permissions/temp-local-admin/`** — JIT checkout/checkin of an ephemeral local account on a standalone ESXi host. The account is created with `shellAccess=true`, so the same JIT identity works for **both web UI and SSH** access (SSH service must be enabled on the host). Account name is the requestor's email local part (`clint.pollock@example.com` → `clint.pollock`); name-collision risk and an opt-in commented-out `ESXI_ENABLE_SSH` extension are documented in the README.
- **`rotate/rotate-esxi-account.py`** — rotate the stored secret of an existing local account (uses `UpdateUser` on `ha-localacctmgr`).
- **`scans/scan-esxi-users.py`** — IAM scan emitting the Britive Resource Manager JSON format.

### `VMware/vCenter/`

- **`permissions/temp-vcenter-admin/`** — JIT Administrator role grant on an existing SSO/AD identity at the vCenter root (`group-d1`). No local account is created — vCenter has a different identity model (SSO + federation), so the realistic JIT pattern is role-grant rather than create-user. `VCENTER_PRINCIPAL`, `VCENTER_ROLE_ID`, `VCENTER_ROOT_MOID`, and `VCENTER_PROPAGATE` are tunable.

### Notes

- ESXi scripts that perform write operations require **vSphere Standard or higher** (free/unlicensed ESXi disables write API after the 60-day eval). Documented in `VMware/ESXi/README.md`.
- README structure follows the recent `k8s/permissions/k8s-exec-bridge/README.md` template — Required/Optional env-var split, `How It Works`, host setup, broker container requirements, Britive Platform setup, manual test run.
- `rotate/` and `scans/` are intentionally **not** included for vCenter — SSO local-user ops live behind a separate `/sso-adminserver/sdk/vsphere.local` endpoint and most customers federate SSO with AD and rotate there. Documented as deferred in `VMware/vCenter/README.md`.

## Test plan

- [ ] Standalone ESXi 7.0/8.0: `temp-local-admin` checkout creates account, grants Administrator, web UI sign-in works
- [ ] Same: SSH sign-in works once `TSM-SSH` service is started on the host
- [ ] Same: checkin removes the account and the role binding
- [ ] Standalone ESXi: `rotate-esxi-account.py` rotates the secret of an existing local account
- [ ] Standalone ESXi: `scan-esxi-users.py` produces the expected Resource Manager JSON document at `BROKER_INJECTED_SCAN_OUTPUT_PATH`
- [ ] vCenter 8.0: `temp-vcenter-admin` checkout grants Administrator at `group-d1` to the requestor's federated identity
- [ ] vCenter 8.0: requestor signs in with their usual identity and sees the elevated role
- [ ] vCenter 8.0: checkin revokes the binding
- [ ] vCenter 8.0: `VCENTER_PRINCIPAL` override works for AD downlevel logon names (`EXAMPLE\jdoe`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)