### PR TITLE
Add MySQL scan + rotation, Windows provision scan, harden Linux scan

### DIFF
--- a/Active Directory/scans/ad-scan_2.ps1
+++ b/Active Directory/scans/ad-scan_2.ps1
@@ -1,0 +1,152 @@
+# ============================================================
+# Active Directory IAM-Style Broker Scan – Optimised v3
+# ============================================================
+# Required env var:
+#   BROKER_INJECTED_SCAN_OUTPUT_PATH
+#
+# Changes from v2:
+#   - Fixed bug where newline sanitization was overwritten
+#   - CNF conflict objects are now skipped
+#   - All sanitization applied correctly before truncation
+# ============================================================
+
+try {
+    $ErrorActionPreference = 'Stop'
+
+    if (-not $env:BROKER_INJECTED_SCAN_OUTPUT_PATH) {
+        throw "BROKER_INJECTED_SCAN_OUTPUT_PATH environment variable is not set."
+    }
+
+    $outputPath = $env:BROKER_INJECTED_SCAN_OUTPUT_PATH
+    Write-Host "Running AD IAM-style broker scan (optimised v3)..."
+    Write-Host "Output path: $outputPath"
+
+    $outputDir = Split-Path -Path $outputPath -Parent
+    if ($outputDir -and -not (Test-Path $outputDir)) {
+        New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+    }
+
+    Import-Module ActiveDirectory -ErrorAction Stop
+    Write-Host "ActiveDirectory module loaded successfully."
+
+    $domain   = Get-ADDomain
+    $domainDN = $domain.DistinguishedName
+    Write-Host "Connected to domain: $($domain.DNSRoot) ($domainDN)"
+
+    $now        = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $identities = [System.Collections.Generic.List[object]]::new()
+    $groups     = [System.Collections.Generic.List[object]]::new()
+
+    # USERS
+    Write-Host "Scanning users..."
+    $adUsers = Get-ADUser -Filter * -Properties Mail, GivenName, Surname, UserPrincipalName, Enabled
+    $dnToSam = @{}
+
+    foreach ($user in $adUsers) {
+        $uid = $user.SamAccountName
+        $dnToSam[$user.DistinguishedName] = $uid
+
+        $identities.Add(@{
+            id          = $uid
+            name        = $uid
+            type        = "User"
+            description = "Active Directory user"
+            created_on  = $now
+            is_active   = [bool]$user.Enabled
+            attributes  = @{
+                email               = if ($user.Mail)              { $user.Mail }              else { "$uid@placeholder.local" }
+                first_name          = if ($user.GivenName)         { $user.GivenName }         else { "NA" }
+                last_name           = if ($user.Surname)           { $user.Surname }           else { "NA" }
+                samaccountname      = $uid
+                user_principal_name = if ($user.UserPrincipalName) { $user.UserPrincipalName } else { "" }
+                distinguished_name  = $user.DistinguishedName
+            }
+        })
+    }
+    Write-Host "Found $($identities.Count) users."
+
+    # GROUPS
+    Write-Host "Scanning groups..."
+    $adGroups = Get-ADGroup -Filter * -Properties DistinguishedName, Members
+    $skipped  = 0
+    $cnfSkipped = 0
+
+    foreach ($group in $adGroups) {
+        # Skip CNF conflict objects
+        if ($group.Name -match "CNF:") {
+            $cnfSkipped++
+            continue
+        }
+
+        # Sanitize: strip newlines/tabs then truncate to 255
+        $groupName = ($group.Name -replace "[\r\n\t]", " ").Trim()
+        $groupName = if ($groupName.Length -gt 255) { $groupName.Substring(0, 255) } else { $groupName }
+
+        $members = [System.Collections.Generic.List[string]]::new()
+
+        if ($group.Members.Count -gt 0) {
+            foreach ($memberDN in $group.Members) {
+                if ($dnToSam.ContainsKey($memberDN)) {
+                    $members.Add($dnToSam[$memberDN])
+                }
+            }
+        } else {
+            $skipped++
+        }
+
+        $groups.Add(@{
+            id          = $groupName
+            name        = $groupName
+            type        = "User group"
+            description = "Active Directory group"
+            created_on  = $now
+            is_active   = $true
+            members     = $members.ToArray()
+            attributes  = @{
+                samaccountname     = $group.SamAccountName
+                distinguished_name = $group.DistinguishedName
+            }
+        })
+    }
+    Write-Host "Found $($groups.Count) groups ($skipped empty, $cnfSkipped CNF skipped)."
+
+    $output = @{
+        data = @{
+            identities         = $identities.ToArray()
+            groups             = $groups.ToArray()
+            permissions        = @()
+            permission_mapping = @()
+        }
+        metadata = @{
+            resource_id   = $domainDN
+            resource_type = "ActiveDirectory"
+            scan_time     = $now
+            scan_details  = "AD scan completed. Users: $($identities.Count), Groups: $($groups.Count), Empty groups skipped: $skipped, CNF groups skipped: $cnfSkipped"
+            scan_errors   = ""
+            attribute_resolution = @{
+                group_membership   = "id"
+                permission_mapping = "id"
+            }
+        }
+    }
+
+    $output | ConvertTo-Json -Depth 10 | Out-File $outputPath -Encoding utf8 -Force
+    Write-Host "AD Broker scan completed successfully."
+    exit 0
+}
+catch {
+    Write-Host "Scan failed: $($_.Exception.Message)"
+
+    $errorOutput = @{
+        data     = @{ groups = @(); identities = @(); permissions = @(); permission_mapping = @() }
+        metadata = @{ scan_errors = $_.Exception.Message; scan_time = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ") }
+    }
+
+    if ($env:BROKER_INJECTED_SCAN_OUTPUT_PATH) {
+        $errorPath = $env:BROKER_INJECTED_SCAN_OUTPUT_PATH
+        $errorDir  = Split-Path -Path $errorPath -Parent
+        if ($errorDir -and -not (Test-Path $errorDir)) { New-Item -ItemType Directory -Path $errorDir -Force | Out-Null }
+        $errorOutput | ConvertTo-Json -Depth 10 | Out-File $errorPath -Encoding utf8 -Force
+    }
+    exit 1
+}

--- a/Aurora MySQL/rotate/README.md
+++ b/Aurora MySQL/rotate/README.md
@@ -1,0 +1,39 @@
+## MySQL / Aurora Account Password Rotation
+
+Rotates the password of a MySQL / Aurora database account. The broker runs `rotate-mysql-user.sh`, which connects with **vaulted admin credentials** (AWS Secrets Manager) and runs `ALTER USER` to set the new password on the target account. It mirrors the connection contract of the [MySQL scan](../scans/README.md); the account to rotate and the new password are injected by the broker.
+
+### Script: `rotate-mysql-user.sh`
+
+The Britive account name is the native MySQL identity `user@host` (e.g. `readonly_user@%`). The script splits it on the **last** `@` into the user and host parts and rotates `ALTER USER 'user'@'host'`.
+
+#### Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `RESOURCE_URL` | Yes | — | RDS / Aurora endpoint hostname. |
+| `RESOURCE_AWSSECRETID` | Yes | — | Secrets Manager secret ID holding the **admin** `{username, password}` used to connect. (Mixed-case `RESOURCE_AWSsecretID` also accepted.) |
+| `RESOURCE_ACCOUNT_NAME` | Yes | — | The account to rotate, as `user@host` (e.g. `readonly_user@%`). |
+| `NEW_PASSWORD` | Yes | — | The new password to set on the account. |
+| `RESOURCE_AWS_SECRET_REGION` | No | `us-west-2` | AWS region where the admin secret lives. |
+| `DB_PORT` | No | `3306` | MySQL port on the endpoint. |
+| `DB_CA_CERT` | No | — | Path to the [RDS CA bundle](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem) on the broker; enables server cert verification. Without it the connection is encrypted but the chain is not verified. |
+
+#### How It Works
+
+1. Validates required inputs and the `mysql`/`aws`/`jq` commands; fails fast otherwise.
+2. Splits `RESOURCE_ACCOUNT_NAME` into `user`/`host` on the last `@` (defaults host to `%` if absent).
+3. Fetches the admin `{username, password}` from Secrets Manager and writes a `600` `[client]` config (admin credentials never appear on the command line).
+4. TLS to the endpoint: verifies against `DB_CA_CERT` when provided, otherwise stays encrypted but skips chain verification (option names differ for MariaDB vs Oracle MySQL clients).
+5. Verifies the target account exists in `mysql.user`; fails if not.
+6. Runs `ALTER USER 'user'@'host' IDENTIFIED BY '<new>'`. The new password is **SQL-escaped** and piped over **stdin** so it never appears in the process list or shell history, and is never logged.
+7. Exits `0` on success, `1` (with a message on stderr) on any failure.
+
+#### Prerequisites
+
+- **Broker host:** `sh`, `mysql` client, `aws` CLI (with `secretsmanager:GetSecretValue` on the admin secret), `jq`; network reachability to the endpoint on `DB_PORT`.
+- **Database:** the admin account in the secret must be able to `ALTER USER` the target account (and `SELECT` on `mysql.user` for the existence check). The RDS master user has this.
+
+#### Notes
+
+- Rotates an account **other than** the admin. Rotating the admin account itself would leave the Secrets Manager copy stale — manage the admin secret separately.
+- `ALTER USER` only changes the password; grants/roles on the account are unchanged.

--- a/Aurora MySQL/rotate/rotate-mysql-user.sh
+++ b/Aurora MySQL/rotate/rotate-mysql-user.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+set -eu
+
+# ============================================================
+# MySQL / Aurora Account Password Rotation
+# ============================================================
+# Rotates the password of a MySQL / Aurora database account by
+# connecting with vaulted admin credentials (AWS Secrets Manager)
+# and running ALTER USER. Mirrors the connection contract of the
+# MySQL scan script; the account to rotate and the new password
+# are injected by the broker.
+#
+# The Britive account name is the native MySQL identity
+# "user@host" (e.g. "readonly_user@%"). It is split on the last
+# '@' into the user and host parts for ALTER USER 'user'@'host'.
+#
+# Required env vars:
+#   RESOURCE_URL                 - RDS / Aurora endpoint hostname
+#   RESOURCE_AWSSECRETID         - Secrets Manager secret ID holding the
+#                                  ADMIN {username, password} used to connect
+#   RESOURCE_ACCOUNT_NAME        - account to rotate, "user@host"
+#                                  (e.g. "readonly_user@%")
+#   NEW_PASSWORD                 - the new password to set on the account
+#
+# Optional env vars:
+#   RESOURCE_AWS_SECRET_REGION   - AWS region of the secret (default: us-west-2)
+#   DB_PORT                      - MySQL port (default: 3306)
+#   DB_CA_CERT                   - path to the RDS CA bundle on the broker;
+#                                  enables server cert verification. Without it
+#                                  the connection is encrypted but the chain is
+#                                  not verified.
+#                                  https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+#
+# The new password is never logged and is sent to mysql over stdin
+# (never on the command line / process list).
+# ============================================================
+
+fail() { echo "rotation FAILED: $1" >&2; exit 1; }
+
+# ---- validate required inputs -----------------------------
+DB_URL="${RESOURCE_URL:-}"
+SECRET_ID="${RESOURCE_AWSSECRETID:-${RESOURCE_AWSsecretID:-}}"
+ACCOUNT_NAME="${RESOURCE_ACCOUNT_NAME:-}"
+NEW_PASSWORD="${NEW_PASSWORD:-}"
+SECRET_REGION="${RESOURCE_AWS_SECRET_REGION:-us-west-2}"
+DB_PORT="${DB_PORT:-3306}"
+DB_CA_CERT="${DB_CA_CERT:-}"
+
+[ -n "$DB_URL" ]       || fail "RESOURCE_URL not set."
+[ -n "$SECRET_ID" ]    || fail "RESOURCE_AWSSECRETID not set."
+[ -n "$ACCOUNT_NAME" ] || fail "RESOURCE_ACCOUNT_NAME not set (expected 'user@host')."
+[ -n "$NEW_PASSWORD" ] || fail "NEW_PASSWORD not set. Cannot rotate."
+
+for cmd in mysql aws jq; do
+    command -v "$cmd" >/dev/null 2>&1 || fail "required command not found on broker: $cmd"
+done
+
+# ---- split "user@host" on the LAST '@' --------------------
+# A MySQL account is user@host; the username itself may contain '@',
+# so split on the final '@'. If there is no '@', default host to '%'.
+case "$ACCOUNT_NAME" in
+    *@*)
+        DB_USER="${ACCOUNT_NAME%@*}"
+        DB_HOST="${ACCOUNT_NAME##*@}"
+        ;;
+    *)
+        DB_USER="$ACCOUNT_NAME"
+        DB_HOST="%"
+        ;;
+esac
+[ -n "$DB_USER" ] || fail "could not parse username from RESOURCE_ACCOUNT_NAME='$ACCOUNT_NAME'."
+[ -n "$DB_HOST" ] || DB_HOST="%"
+
+echo "Starting MySQL account password rotation..." >&2
+echo "  Endpoint : $DB_URL" >&2
+echo "  Account  : ${DB_USER}@${DB_HOST}" >&2
+
+# ---- temp files with restrictive perms --------------------
+TMP_CONF="$(mktemp)"
+chmod 600 "$TMP_CONF"
+trap 'rm -f "$TMP_CONF"' EXIT INT TERM
+
+# ---- fetch admin creds from Secrets Manager ---------------
+SECRET_VALUE="$(aws secretsmanager get-secret-value \
+    --secret-id "$SECRET_ID" \
+    --region "$SECRET_REGION" \
+    --query 'SecretString' \
+    --output text 2>/dev/null)" || fail "failed to read secret $SECRET_ID from Secrets Manager ($SECRET_REGION)."
+
+DB_ADMIN_USER="$(printf '%s' "$SECRET_VALUE" | jq -r '.username')"
+DB_ADMIN_PASSWORD="$(printf '%s' "$SECRET_VALUE" | jq -r '.password')"
+[ -n "$DB_ADMIN_USER" ] && [ "$DB_ADMIN_USER" != "null" ] || fail "secret $SECRET_ID missing 'username'/'password' keys."
+
+# ---- build [client] config (creds never on the command line) ----
+cat > "$TMP_CONF" <<EOF
+[client]
+user = $DB_ADMIN_USER
+password = $DB_ADMIN_PASSWORD
+host = $DB_URL
+port = $DB_PORT
+EOF
+
+# TLS: newer MariaDB clients verify the server cert by default and reject the
+# RDS CA. Verify against DB_CA_CERT when provided; otherwise stay encrypted but
+# skip chain verification. Option names differ per client flavor.
+if mysql --version 2>/dev/null | grep -qi mariadb; then
+    if [ -n "$DB_CA_CERT" ]; then
+        printf 'ssl-ca = %s\nssl-verify-server-cert = 1\n' "$DB_CA_CERT" >> "$TMP_CONF"
+    else
+        printf 'ssl-verify-server-cert = 0\n' >> "$TMP_CONF"
+    fi
+else
+    if [ -n "$DB_CA_CERT" ]; then
+        printf 'ssl-ca = %s\nssl-mode = VERIFY_CA\n' "$DB_CA_CERT" >> "$TMP_CONF"
+    else
+        printf 'ssl-mode = REQUIRED\n' >> "$TMP_CONF"
+    fi
+fi
+
+# ---- SQL-escape identifiers and the new password ----------
+# MySQL string literals: escape backslash first, then single quote.
+sql_escape() { printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e "s/'/\\\\'/g"; }
+USER_ESC="$(sql_escape "$DB_USER")"
+HOST_ESC="$(sql_escape "$DB_HOST")"
+PW_ESC="$(sql_escape "$NEW_PASSWORD")"
+
+# ---- verify the account exists ----------------------------
+EXISTS="$(mysql --defaults-extra-file="$TMP_CONF" -B -N -e \
+    "SELECT COUNT(*) FROM mysql.user WHERE User = '$USER_ESC' AND Host = '$HOST_ESC';" 2>/dev/null)" \
+    || fail "could not query mysql.user (check admin privileges / connectivity)."
+[ "$EXISTS" = "1" ] || fail "account '${DB_USER}'@'${DB_HOST}' does not exist on $DB_URL."
+
+# ---- rotate the password ----------------------------------
+# Statement is piped over stdin so the new password never appears in the
+# process list or shell history.
+printf "ALTER USER '%s'@'%s' IDENTIFIED BY '%s';\n" "$USER_ESC" "$HOST_ESC" "$PW_ESC" \
+    | mysql --defaults-extra-file="$TMP_CONF" \
+    || fail "ALTER USER failed for '${DB_USER}'@'${DB_HOST}'."
+
+echo "MySQL account password rotation completed successfully." >&2
+echo "  Account : ${DB_USER}@${DB_HOST}" >&2
+echo "  Endpoint: $DB_URL" >&2
+exit 0

--- a/Aurora MySQL/scans/README.md
+++ b/Aurora MySQL/scans/README.md
@@ -1,0 +1,59 @@
+## MySQL / Aurora DB Scan
+
+This directory contains a POSIX shell script that scans a **MySQL / Aurora RDS instance** for its database accounts (users) and roles (and the role→user assignments), and outputs the data as JSON for the Britive Resource Manager. The output schema matches the [Linux](../../Linux/scans/README.md) and [Windows](../../Windows/scans/README.md) VM scans so local database identities and roles are stored per instance in the same shape.
+
+### Script: `mysql-scan.sh`
+
+Runs on the Britive broker. It reads vaulted admin credentials from AWS Secrets Manager (the same pattern as the [temp-user](../permissions/temp-user/README.md) checkout scripts), connects to the RDS/Aurora endpoint with the `mysql` client, and enumerates:
+
+- **Identities** — login accounts from `mysql.user`.
+- **Groups** — MySQL **roles**, with members (grantees) from `mysql.role_edges`.
+- **Permissions** — left empty (defined in the resource type, matching the other scans).
+
+JSON is assembled with `jq` for safe escaping.
+
+#### Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `BROKER_INJECTED_SCAN_OUTPUT_PATH` | Yes | — | Full file path where the scan JSON is written. Injected by the broker at runtime. |
+| `RESOURCE_URL` | Yes | — | RDS / Aurora endpoint hostname. Broker-injected resource param. |
+| `RESOURCE_AWSSECRETID` | Yes | — | Secrets Manager secret ID holding admin `{username, password}`. Broker-injected. (The mixed-case form `RESOURCE_AWSsecretID` is also accepted.) |
+| `RESOURCE_AWS_SECRET_REGION` | No | `us-west-2` | AWS region where the secret lives. Broker-injected. |
+| `DB_PORT` | No | `3306` | MySQL port on the endpoint. |
+| `DB_CA_CERT` | No | — | Path to the [RDS CA bundle](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem) on the broker; enables server cert verification. Without it the connection is encrypted but the chain is not verified. |
+
+#### How It Works
+
+1. Validates `BROKER_INJECTED_SCAN_OUTPUT_PATH`, `RESOURCE_URL`, `RESOURCE_AWSSECRETID`, and the `mysql`/`aws`/`jq` commands.
+2. Fetches admin `{username, password}` from Secrets Manager and writes a `600` `[client]` config (credentials never appear on the command line).
+3. TLS to the endpoint: verifies against `DB_CA_CERT` when provided, otherwise stays encrypted but skips chain verification (option names differ for MariaDB vs Oracle MySQL clients).
+4. **Users** — `SELECT User, Host, account_locked, password_expired, plugin FROM mysql.user`. `is_active` is `false` when `account_locked = 'Y'`.
+5. **Roles** — `SELECT FROM_USER, FROM_HOST, TO_USER, TO_HOST FROM mysql.role_edges`. An account that is granted to others (appears as `FROM`) is treated as a role; members are the `TO` grantees. `role_edges` only exists on MySQL 8.0+; on 5.7 the query degrades to "no roles".
+6. Writes the JSON to the broker-specified path.
+7. On any failure, writes a minimal valid JSON with the error message so the broker can report it back.
+
+#### Identity Resolution
+
+- **User `id`** and **role `id`** use `user@host` (e.g. `alice@%`) — the real MySQL account identity, since the same username can exist for multiple hosts.
+- **Role `members`** arrays contain `user@host` values matching identity `id`s, so `attribute_resolution.group_membership = "id"` resolves correctly.
+- Host, `account_locked`, `password_expired`, and `auth_plugin` are kept in `attributes` for reference.
+
+#### Output Schema
+
+- **`data.identities`** — database users with attributes: `username`, `email` (`<user>@<endpoint>` — the platform requires a non-null email), `host`, `account_locked`, `password_expired`, `auth_plugin`.
+- **`data.groups`** — MySQL roles with member lists and attributes: `rolename`, `host`.
+- **`data.permissions`** — empty (permissions are defined in the resource type).
+- **`data.permission_mapping`** — empty (role-to-user lives in `groups.members`).
+- **`metadata`** — `resource_id` (endpoint), `resource_type` = `MySQLDB`, `scan_time`, `scan_details`, `scan_errors`, `attribute_resolution`.
+
+#### Prerequisites
+
+**Broker host:** `sh`, `mysql` client, `aws` CLI (with `secretsmanager:GetSecretValue` on the secret), `jq`, `mktemp`; network reachability to the RDS/Aurora endpoint on `DB_PORT`.
+
+**Database:** the admin account in the secret must have `SELECT` on `mysql.user` and `mysql.role_edges`. The RDS master user has this by default.
+
+#### Limitations
+
+- A role with **no grantees** is indistinguishable from a user (MySQL has no authoritative "is role" column) and is reported as a user.
+- Direct object privileges (`GRANT`s) are not enumerated — the scan captures identities, roles, and role membership only.

--- a/Aurora MySQL/scans/mysql-scan.sh
+++ b/Aurora MySQL/scans/mysql-scan.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+set -eu
+
+# ============================================================
+# MySQL / Aurora IAM-Style Broker Scan
+# ============================================================
+# Runs on the Britive broker. Connects to a MySQL / Aurora RDS
+# instance with vaulted admin credentials, enumerates database
+# accounts (mysql.user) and roles (mysql.role_edges), builds a
+# JSON payload in the Britive Resource Manager schema, and writes
+# it to the path supplied by the broker.
+#
+# Identities  = login accounts in mysql.user
+# Groups      = MySQL roles (accounts granted to others via
+#               mysql.role_edges); members are the grantees
+# Permissions = defined in the resource type, so left empty here
+#
+# Broker-injected resource params (plaintext env vars):
+#   RESOURCE_URL                 - RDS / Aurora endpoint hostname   (required)
+#   RESOURCE_AWSSECRETID         - Secrets Manager secret ID holding
+#                                  admin {username, password}       (required)
+#   RESOURCE_AWS_SECRET_REGION   - AWS region of the secret         (default: us-west-2)
+#
+# Broker-supplied:
+#   BROKER_INJECTED_SCAN_OUTPUT_PATH - full path for JSON output    (required)
+#
+# Optional:
+#   DB_PORT      - MySQL port (default: 3306)
+#   DB_CA_CERT   - path to the RDS CA bundle on the broker; enables
+#                  server cert verification. Without it the connection
+#                  is encrypted but the chain is not verified.
+#                  https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+#
+# Identity IDs are "user@host" so that
+# attribute_resolution.group_membership = "id" resolves against the
+# grantee references in mysql.role_edges.
+# ============================================================
+
+# ---- broker-side validation -------------------------------
+if [ -z "${BROKER_INJECTED_SCAN_OUTPUT_PATH:-}" ]; then
+    echo "ERROR: BROKER_INJECTED_SCAN_OUTPUT_PATH not set. Cannot write scan output." >&2
+    exit 1
+fi
+OUTPUT_PATH="$BROKER_INJECTED_SCAN_OUTPUT_PATH"
+
+# Broker uppercases resource param names; tolerate the mixed-case form too.
+DB_URL="${RESOURCE_URL:-}"
+SECRET_ID="${RESOURCE_AWSSECRETID:-${RESOURCE_AWSsecretID:-}}"
+SECRET_REGION="${RESOURCE_AWS_SECRET_REGION:-us-west-2}"
+DB_PORT="${DB_PORT:-3306}"
+DB_CA_CERT="${DB_CA_CERT:-}"
+
+OUT_DIR="$(dirname "$OUTPUT_PATH")"
+[ -d "$OUT_DIR" ] || mkdir -p "$OUT_DIR"
+
+# ---- error JSON helper ------------------------------------
+# write_error <message>
+write_error() {
+    _msg="$1"
+    _now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    if command -v jq >/dev/null 2>&1; then
+        jq -n --arg e "$_msg" --arg t "$_now" \
+          '{data:{identities:[],groups:[],permissions:[],permission_mapping:[]},
+            metadata:{scan_errors:$e,scan_time:$t}}' > "$OUTPUT_PATH"
+    else
+        _esc="$(printf '%s' "$_msg" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
+        cat > "$OUTPUT_PATH" <<EOF
+{
+  "data": { "identities": [], "groups": [], "permissions": [], "permission_mapping": [] },
+  "metadata": { "scan_errors": "$_esc", "scan_time": "$_now" }
+}
+EOF
+    fi
+}
+
+# ---- fail-fast checks -------------------------------------
+for cmd in mysql aws jq; do
+    command -v "$cmd" >/dev/null 2>&1 || {
+        write_error "required command not found on broker: $cmd"
+        echo "ERROR: required command not found: $cmd" >&2
+        exit 1
+    }
+done
+[ -n "$DB_URL" ]    || { write_error "RESOURCE_URL empty"; echo "ERROR: RESOURCE_URL empty" >&2; exit 1; }
+[ -n "$SECRET_ID" ] || { write_error "RESOURCE_AWSSECRETID empty"; echo "ERROR: RESOURCE_AWSSECRETID empty" >&2; exit 1; }
+
+echo "Running MySQL IAM-style broker scan against $DB_URL..." >&2
+echo "Output path: $OUTPUT_PATH" >&2
+
+# ---- temp files with restrictive perms --------------------
+TMP_CONF="$(mktemp)"
+USERS_FILE="$(mktemp)"
+EDGES_FILE="$(mktemp)"
+chmod 600 "$TMP_CONF" "$USERS_FILE" "$EDGES_FILE"
+trap 'rm -f "$TMP_CONF" "$USERS_FILE" "$EDGES_FILE"' EXIT INT TERM
+
+# ---- fetch admin creds from Secrets Manager ---------------
+SECRET_VALUE="$(aws secretsmanager get-secret-value \
+    --secret-id "$SECRET_ID" \
+    --region "$SECRET_REGION" \
+    --query 'SecretString' \
+    --output text 2>/dev/null)" || {
+    write_error "failed to read secret $SECRET_ID from Secrets Manager ($SECRET_REGION)"
+    echo "ERROR: Secrets Manager read failed" >&2
+    exit 1
+}
+
+DB_ADMIN_USER="$(printf '%s' "$SECRET_VALUE" | jq -r '.username')"
+DB_ADMIN_PASSWORD="$(printf '%s' "$SECRET_VALUE" | jq -r '.password')"
+if [ -z "$DB_ADMIN_USER" ] || [ "$DB_ADMIN_USER" = "null" ]; then
+    write_error "secret $SECRET_ID missing 'username'/'password' keys"
+    echo "ERROR: secret missing username/password" >&2
+    exit 1
+fi
+
+# ---- build [client] config (no quotes; mysql reads values literally) ----
+cat > "$TMP_CONF" <<EOF
+[client]
+user = $DB_ADMIN_USER
+password = $DB_ADMIN_PASSWORD
+host = $DB_URL
+port = $DB_PORT
+EOF
+
+# TLS: newer MariaDB clients verify the server cert by default and reject the
+# RDS CA. Verify against DB_CA_CERT when provided; otherwise stay encrypted but
+# skip chain verification. Option names differ per client flavor.
+if mysql --version 2>/dev/null | grep -qi mariadb; then
+    if [ -n "$DB_CA_CERT" ]; then
+        printf 'ssl-ca = %s\nssl-verify-server-cert = 1\n' "$DB_CA_CERT" >> "$TMP_CONF"
+    else
+        printf 'ssl-verify-server-cert = 0\n' >> "$TMP_CONF"
+    fi
+else
+    if [ -n "$DB_CA_CERT" ]; then
+        printf 'ssl-ca = %s\nssl-mode = VERIFY_CA\n' "$DB_CA_CERT" >> "$TMP_CONF"
+    else
+        printf 'ssl-mode = REQUIRED\n' >> "$TMP_CONF"
+    fi
+fi
+
+# ---- query accounts and role edges ------------------------
+# -B batch (tab-separated), -N no column headers, -r raw (no escaping).
+if ! mysql --defaults-extra-file="$TMP_CONF" -B -N -r -e \
+    "SELECT User, Host, account_locked, password_expired, plugin FROM mysql.user ORDER BY User, Host;" \
+    > "$USERS_FILE" 2>"$USERS_FILE.err"; then
+    write_error "mysql.user query failed: $(cat "$USERS_FILE.err" 2>/dev/null)"
+    rm -f "$USERS_FILE.err"
+    echo "ERROR: mysql.user query failed" >&2
+    exit 1
+fi
+rm -f "$USERS_FILE.err"
+
+# role_edges only exists on MySQL 8.0+; treat its absence as "no roles".
+mysql --defaults-extra-file="$TMP_CONF" -B -N -r -e \
+    "SELECT FROM_USER, FROM_HOST, TO_USER, TO_HOST FROM mysql.role_edges ORDER BY FROM_USER, FROM_HOST;" \
+    > "$EDGES_FILE" 2>/dev/null || : > "$EDGES_FILE"
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# ---- assemble Britive Resource Manager schema with jq -----
+# A MySQL role is an account that is granted to others (appears as FROM in
+# role_edges). Such accounts become groups; the rest are user identities.
+# NOTE: a role with no grantees is indistinguishable from a user here and is
+# reported as a user.
+jq -n \
+  --arg now "$NOW" \
+  --arg resource_id "$DB_URL" \
+  --rawfile users_raw "$USERS_FILE" \
+  --rawfile edges_raw "$EDGES_FILE" \
+  '
+  def rows($raw): $raw | split("\n") | map(select(length > 0) | split("\t"));
+  rows($users_raw) as $u
+  | rows($edges_raw) as $e
+  | ($e | map(.[0] + "@" + .[1]) | unique) as $roleIds
+  | ($u | map({
+        id:     (.[0] + "@" + .[1]),
+        user:   .[0],
+        host:   .[1],
+        locked: .[2],
+        pwexp:  .[3],
+        plugin: .[4]
+    })) as $accts
+  | {
+      data: {
+        identities: ($accts
+          | map(select(.id as $iid | ($roleIds | index($iid)) == null))
+          | map({
+              id:          .id,
+              name:        .user,
+              type:        "User",
+              description: "MySQL database user",
+              created_on:  $now,
+              is_active:   (.locked != "Y"),
+              attributes: {
+                username:          .user,
+                email:             (.user + "@" + $resource_id),
+                host:              .host,
+                account_locked:    .locked,
+                password_expired:  .pwexp,
+                auth_plugin:       .plugin
+              }
+            })),
+        groups: ($accts
+          | map(select(.id as $iid | ($roleIds | index($iid)) != null))
+          | map(. as $r
+              | ($e
+                  | map(select(.[0] == $r.user and .[1] == $r.host) | (.[2] + "@" + .[3])))
+                as $members
+              | {
+                  id:          $r.id,
+                  name:        $r.user,
+                  type:        "User group",
+                  description: "MySQL role",
+                  created_on:  $now,
+                  is_active:   true,
+                  members:     $members,
+                  attributes: {
+                    rolename: $r.user,
+                    host:     $r.host
+                  }
+                })),
+        permissions: [],
+        permission_mapping: []
+      },
+      metadata: {
+        resource_id:   $resource_id,
+        resource_type: "MySQLDB",
+        scan_time:     $now,
+        scan_details:  ("MySQL scan completed on " + $resource_id + "."),
+        scan_errors:   "",
+        attribute_resolution: {
+          group_membership:   "id",
+          permission_mapping: "id"
+        }
+      }
+    }
+  ' > "$OUTPUT_PATH"
+
+USER_COUNT="$(jq '.data.identities | length' "$OUTPUT_PATH")"
+ROLE_COUNT="$(jq '.data.groups | length' "$OUTPUT_PATH")"
+echo "MySQL broker scan completed successfully. Users: $USER_COUNT, Roles: $ROLE_COUNT" >&2
+exit 0

--- a/Linux/scans/README.md
+++ b/Linux/scans/README.md
@@ -11,20 +11,22 @@ Runs on the Britive broker. It SSHes into a target Linux VM (using the same conn
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `BROKER_INJECTED_SCAN_OUTPUT_PATH` | Yes | — | Full file path where the scan JSON is written. Injected by the broker at runtime. |
-| `BRITIVE_REMOTE_HOST` (or `HOST`) | Yes | — | Target VM hostname / IP. |
-| `REMOTE_USER` | No | `britivebroker` | SSH login user on the target VM. |
-| `REMOTE_KEY` | No | `/home/britivebroker/.ssh/MYKEY.pem` | Path to the broker's SSH private key. |
+| `RESOURCE_HOST` | Yes | — | Target server hostname / IP. Broker-injected (same as the checkout/checkin scripts). |
+| `RESOURCE_USER` | No | `britivebroker` | Remote provisioning SSH user on the target. Broker-injected. |
+| `RESOURCE_KEY_LOCATION` | No | `/home/britivebroker/.ssh/MYKEY.pem` | Path to the provisioning user's SSH private key. Broker-injected. |
 | `SCAN_MIN_UID` | No | `0` | Lowest UID to include (e.g. `1000` to skip system accounts). |
+
+Legacy names `BRITIVE_REMOTE_HOST`/`HOST`, `REMOTE_USER`, and `REMOTE_KEY` are still honored as fallbacks if the `RESOURCE_*` params are absent.
 
 #### How It Works
 
 1. Validates `BROKER_INJECTED_SCAN_OUTPUT_PATH` is set (fails immediately if not).
-2. Validates the target host and the broker SSH key exist.
-3. SSHes into the VM and runs the embedded scanner.
-4. **Users** — `getent passwd` (filtered by `SCAN_MIN_UID`). Captures `uid`, `gid`, `first_name`/`last_name` (parsed from GECOS), `gecos`, `home`, `shell`. `is_active` is `false` for nologin/false shells or accounts locked in `/etc/shadow` (`!`/`*`).
+2. Validates the target host (`RESOURCE_HOST`) and the SSH key (`RESOURCE_KEY_LOCATION`) exist — fails fast before any connection.
+3. SSHes into the VM (`ConnectTimeout=10`, `BatchMode=yes`) and runs the embedded scanner.
+4. **Users** — `getent passwd` (filtered by `SCAN_MIN_UID`; lines with a non-numeric UID are skipped). Captures `uid`, `gid`, `first_name`/`last_name` (parsed from GECOS), `gecos`, `home`, `shell`, and a non-null `email` (`<user>@<hostid>`). `is_active` is `false` for nologin/false shells or accounts locked in `/etc/shadow` (`!`/`*`).
 5. **Groups** — `getent group`. Members combine the secondary members on the group line plus users whose **primary** GID matches the group; the list is deduplicated.
-6. Writes the JSON to the broker-specified path.
-7. On failure, writes a minimal valid JSON with the error message so the broker can report it back to the platform.
+6. **Validates the captured output** (non-empty and begins with `{`) before writing, and verifies the write to the broker path succeeds — so a partial/empty/unwritable result fails loudly instead of exiting `0` with bad output.
+7. On any failure — SSH error, empty/non-JSON output, or write failure — writes a minimal valid JSON with the error message (and the remote stderr) so the broker reports it back to the platform.
 
 #### Identity Resolution
 
@@ -35,7 +37,7 @@ Runs on the Britive broker. It SSHes into a target Linux VM (using the same conn
 
 #### Output Schema
 
-- **`data.identities`** — local users with attributes: `username`, `uid`, `gid`, `first_name`, `last_name`, `gecos`, `home`, `shell`.
+- **`data.identities`** — local users with attributes: `username`, `email` (`<user>@<hostid>` — the platform requires a non-null email), `uid`, `gid`, `first_name`, `last_name`, `gecos`, `home`, `shell`.
 - **`data.groups`** — local groups with deduplicated member lists and attributes: `groupname`, `gid`.
 - **`data.permissions`** — empty (Linux has no separate permission objects in this model).
 - **`data.permission_mapping`** — empty (user-to-group lives in `groups.members`).
@@ -45,4 +47,8 @@ Runs on the Britive broker. It SSHes into a target Linux VM (using the same conn
 
 **Broker host:** `sh`, `ssh`, `mktemp`; SSH private key readable at `REMOTE_KEY` (`600`); network/SSH (port 22) reachability to the VM.
 
-**Target VM:** SSH daemon running; `REMOTE_USER` able to run `getent passwd`/`getent group`. Reading `/etc/shadow` (for accurate `is_active`) requires root or sudo; without it, locked-account detection degrades gracefully (accounts are reported active based on shell only).
+**Target VM:** SSH daemon running; the provisioning user (`RESOURCE_USER`) able to run `getent passwd`/`getent group`. Reading `/etc/shadow` (for accurate `is_active`) requires root or sudo; without it, locked-account detection degrades gracefully (accounts are reported active based on shell only).
+
+#### Compatibility
+
+Tested against **Ubuntu** and **Amazon Linux** (2 / 2023). The embedded scanner is POSIX `sh` only — no bashisms — so it runs identically whether the target's `/bin/sh` is dash (Ubuntu) or bash (Amazon Linux). It relies only on `getent`, coreutils (`date`, `awk`, `sed`, `cut`, `tr`, `printf`, `head`) and `hostname`; the `nologin` shell match handles both `/usr/sbin/nologin` (Ubuntu) and `/sbin/nologin` (Amazon Linux), and hostname resolution falls back to `uname -n` when the `hostname` binary is absent (e.g. Amazon Linux 2023 minimal).

--- a/Linux/scans/linux-scan.sh
+++ b/Linux/scans/linux-scan.sh
@@ -16,11 +16,18 @@ set -eu
 # Required env var:
 #   BROKER_INJECTED_SCAN_OUTPUT_PATH  – full path for JSON output
 #
-# Connection env vars (mirror the temp-ssh-key-remote scripts):
-#   BRITIVE_REMOTE_HOST (or HOST)  – target VM hostname/IP   (required)
-#   REMOTE_USER                    – ssh login user          (default: britivebroker)
-#   REMOTE_KEY                     – broker private key path  (default: /home/britivebroker/.ssh/MYKEY.pem)
-#   SCAN_MIN_UID                   – lowest UID to include    (default: 0 = all)
+# Broker-injected resource params (plaintext), same as the
+# temp-ssh-key-remote checkout/checkin scripts:
+#   RESOURCE_HOST          – target server hostname/IP        (required)
+#   RESOURCE_USER          – remote provisioning ssh user     (default: britivebroker)
+#   RESOURCE_KEY_LOCATION  – path to the provisioning user's private key
+#                            (default: /home/britivebroker/.ssh/MYKEY.pem)
+#
+# Optional:
+#   SCAN_MIN_UID           – lowest UID to include            (default: 0 = all)
+#
+# (Legacy names BRITIVE_REMOTE_HOST/HOST, REMOTE_USER, REMOTE_KEY are still
+#  honored as fallbacks.)
 #
 # Identity IDs use the local username so that
 # attribute_resolution.group_membership = "id" resolves correctly.
@@ -33,9 +40,9 @@ if [ -z "${BROKER_INJECTED_SCAN_OUTPUT_PATH:-}" ]; then
 fi
 OUTPUT_PATH="$BROKER_INJECTED_SCAN_OUTPUT_PATH"
 
-REMOTE_HOST="${BRITIVE_REMOTE_HOST:-${HOST:-}}"
-REMOTE_USER="${REMOTE_USER:-britivebroker}"
-REMOTE_KEY="${REMOTE_KEY:-/home/britivebroker/.ssh/MYKEY.pem}"
+REMOTE_HOST="${RESOURCE_HOST:-${BRITIVE_REMOTE_HOST:-${HOST:-}}}"
+REMOTE_USER="${RESOURCE_USER:-${REMOTE_USER:-britivebroker}}"
+REMOTE_KEY="${RESOURCE_KEY_LOCATION:-${REMOTE_KEY:-/home/britivebroker/.ssh/MYKEY.pem}}"
 SCAN_MIN_UID="${SCAN_MIN_UID:-0}"
 
 OUT_DIR="$(dirname "$OUTPUT_PATH")"
@@ -57,8 +64,8 @@ EOF
 }
 
 # ---- fail-fast connection checks --------------------------
-[ -z "$REMOTE_HOST" ]  && { write_error "REMOTE_HOST empty — set BRITIVE_REMOTE_HOST"; echo "ERROR: REMOTE_HOST empty" >&2; exit 1; }
-[ -f "$REMOTE_KEY" ]   || { write_error "SSH key not found at $REMOTE_KEY"; echo "ERROR: SSH key not found at $REMOTE_KEY" >&2; exit 1; }
+[ -z "$REMOTE_HOST" ]  && { write_error "RESOURCE_HOST empty — set RESOURCE_HOST"; echo "ERROR: RESOURCE_HOST empty" >&2; exit 1; }
+[ -f "$REMOTE_KEY" ]   || { write_error "SSH key not found at $REMOTE_KEY (RESOURCE_KEY_LOCATION)"; echo "ERROR: SSH key not found at $REMOTE_KEY" >&2; exit 1; }
 
 echo "Running Linux VM IAM-style broker scan against $REMOTE_HOST..."
 echo "Output path: $OUTPUT_PATH"
@@ -87,7 +94,9 @@ esc() {
 }
 
 NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-HOSTID="$(hostname -f 2>/dev/null || hostname)"
+# hostname resolution: prefer FQDN, fall back to short name, then uname -n
+# (the `hostname` binary is not installed by default on Amazon Linux 2023 minimal).
+HOSTID="$(hostname -f 2>/dev/null || hostname 2>/dev/null || uname -n)"
 
 # ---- USERS (local accounts from getent passwd) ----
 # An account is treated as active when its login shell is not a
@@ -95,6 +104,9 @@ HOSTID="$(hostname -f 2>/dev/null || hostname)"
 IDENT_JSON=""
 first=1
 while IFS=: read -r uname pw uid gid gecos home shell; do
+    # skip malformed lines with a non-numeric UID (would break the -lt test
+    # and, under set -e, abort the whole scan)
+    case "$uid" in ''|*[!0-9]*) continue ;; esac
     [ "$uid" -lt "$MIN_UID" ] && continue
     active=true
     case "$shell" in
@@ -180,7 +192,32 @@ if [ "$RC" -ne 0 ]; then
     exit 1
 fi
 
-# move captured remote JSON to the broker output path
-cat "$TMP_OUT" > "$OUTPUT_PATH"
+# ---- validate the captured output before writing it out ----
+# The remote block emits its JSON only as its final action, so a non-empty
+# object starting with '{' means the scan ran to completion.
+if [ ! -s "$TMP_OUT" ]; then
+    ERRMSG="Remote scan returned no output (stderr: $(cat "$TMP_ERR"))"
+    echo "Scan failed: $ERRMSG" >&2
+    write_error "$ERRMSG"
+    exit 1
+fi
+case "$(head -c 1 "$TMP_OUT" 2>/dev/null)" in
+    '{') : ;;
+    *)
+        ERRMSG="Remote scan produced non-JSON output"
+        echo "Scan failed: $ERRMSG" >&2
+        write_error "$ERRMSG"
+        exit 1
+        ;;
+esac
+
+# ---- write the JSON to the broker output path -------------
+# Explicit write check: if the broker path is unwritable (perms/disk), fail
+# loudly rather than exiting 0 with no/partial output.
+if ! cat "$TMP_OUT" > "$OUTPUT_PATH"; then
+    echo "ERROR: failed to write scan output to $OUTPUT_PATH" >&2
+    exit 1
+fi
+
 echo "Linux VM broker scan completed successfully."
 exit 0

--- a/Windows/scans/windows_scan_provision.ps1
+++ b/Windows/scans/windows_scan_provision.ps1
@@ -1,23 +1,23 @@
 # ============================================================
-# Windows VM IAM-Style Broker Scan (remote)
+# Windows VM IAM-Style Broker Scan (remote, provision-cred variant)
 # ============================================================
-# Runs on the Britive broker. Connects to a target Windows VM
-# over WinRM (Invoke-Command), enumerates LOCAL users and groups
-# (and group membership), builds a JSON payload in the Britive
-# Resource Manager schema, and writes it to the broker-supplied
-# output path.
+# Reads broker-injected resource params from RESOURCE_* env vars.
+# NOTE: the broker injects these as PLAINTEXT into the process
+# environment. The base64 form seen in broker logs is only a
+# logging/masking representation — do NOT decode here.
 #
-# Required env var:
-#   BROKER_INJECTED_SCAN_OUTPUT_PATH  – full path for JSON output
+# Broker-injected params (plaintext):
+#   RESOURCE_HOST                 – target VM hostname/IP            (required)
+#   RESOURCE_PROVISION_USERNAME   – WinRM admin user                (default: Administrator)
+#   RESOURCE_PROVISION_PASSWORD   – WinRM admin password            (required)
 #
-# Connection env vars (mirror the local-admin-remote-server scripts):
-#   target (or BRITIVE_REMOTE_HOST)   – target VM hostname/IP   (required)
-#   BRITIVE_REMOTE_USER               – WinRM user (optional; omit to use broker identity)
-#   BRITIVE_REMOTE_PASSWORD           – WinRM password (optional, paired with user)
+# Broker-supplied:
+#   BROKER_INJECTED_SCAN_OUTPUT_PATH – full path for JSON output    (required)
 #
-# Identity IDs use the local account Name so that
-# attribute_resolution.group_membership = "id" resolves correctly.
-# Members reference local user Names; SID is stored in attributes.
+# The provisioning credential is always used (Basic auth) — local admin
+# accounts fail over Negotiate/Kerberos from the broker service context.
+# Basic over HTTP requires WinRM 'AllowUnencrypted=true' on the target
+# (or use HTTPS/5986).
 # ============================================================
 
 try {
@@ -28,9 +28,17 @@ try {
     }
     $outputPath = $env:BROKER_INJECTED_SCAN_OUTPUT_PATH
 
-    $targetComputer = if ($env:target) { $env:target } elseif ($env:BRITIVE_REMOTE_HOST) { $env:BRITIVE_REMOTE_HOST } else { $null }
+    # ---- resolve broker-injected resource params (RESOURCE_*, plaintext) ----
+    $targetComputer = $env:RESOURCE_HOST
     if (-not $targetComputer) {
-        throw "Target computer not set. Provide env var 'target' or 'BRITIVE_REMOTE_HOST'."
+        throw "Target host not set. Provide resource param 'HOST' (env RESOURCE_HOST)."
+    }
+
+    $remoteUser = if ($env:RESOURCE_PROVISION_USERNAME) { $env:RESOURCE_PROVISION_USERNAME } else { "Administrator" }
+
+    $remotePass = $env:RESOURCE_PROVISION_PASSWORD
+    if (-not $remotePass) {
+        throw "Provisioning password not set. Provide resource param 'PROVISION_PASSWORD' (env RESOURCE_PROVISION_PASSWORD)."
     }
 
     Write-Host "Running Windows VM IAM-style broker scan against $targetComputer..."
@@ -43,12 +51,19 @@ try {
         Write-Host "Created output directory: $outputDir"
     }
 
-    # optional explicit credential for WinRM
+    # ---- WinRM invocation params ----
     $invokeParams = @{ ComputerName = $targetComputer }
-    if ($env:BRITIVE_REMOTE_USER -and $env:BRITIVE_REMOTE_PASSWORD) {
-        $secPass = ConvertTo-SecureString $env:BRITIVE_REMOTE_PASSWORD -AsPlainText -Force
-        $invokeParams.Credential = New-Object System.Management.Automation.PSCredential($env:BRITIVE_REMOTE_USER, $secPass)
-    }
+
+    # Fast-fail timeouts: OpenTimeout bounds the WinRM connect so an unreachable
+    # or slow target aborts in ~15s instead of hanging on the default timeouts.
+    $invokeParams.SessionOption = New-PSSessionOption -OpenTimeout 15000 -OperationTimeout 120000 -CancelTimeout 5000
+
+    $secPass = ConvertTo-SecureString $remotePass -AsPlainText -Force
+    $invokeParams.Credential = New-Object System.Management.Automation.PSCredential($remoteUser, $secPass)
+    # Basic auth: local accounts fail over Negotiate/Kerberos from a service
+    # (broker) context with error 0x8009030d. Basic forces a clean local logon.
+    $invokeParams.Authentication = 'Basic'
+    Write-Host "Using provisioning credential (Basic auth) for user: $remoteUser"
 
     $now = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 
@@ -99,6 +114,12 @@ try {
     }
 
     $result = Invoke-Command @invokeParams -ScriptBlock $scriptBlock
+
+    # Guard: a null/empty result means the remote block produced nothing (e.g.
+    # LocalAccounts cmdlets unavailable on an old OS). Fail so it is reported.
+    if (-not $result) {
+        throw "Remote scan against $targetComputer returned no data (target may lack Get-LocalUser/Get-LocalGroup)."
+    }
 
     # ----------------------------------------------------------
     # Build identities

--- a/Windows/scans/windows_scan_script.ps1
+++ b/Windows/scans/windows_scan_script.ps1
@@ -1,0 +1,231 @@
+# ============================================================
+# Windows VM IAM-Style Broker Scan (remote)
+# ============================================================
+# Reads broker-injected resource params from RESOURCE_* env vars.
+# NOTE: the broker injects these as PLAINTEXT into the process
+# environment. The base64 form seen in broker logs is only a
+# logging/masking representation — do NOT decode here.
+#
+# Broker-injected params (plaintext):
+#   RESOURCE_TARGET                  – target VM hostname/IP   (required)
+#   RESOURCE_BRITIVE_REMOTE_USER     – WinRM user (optional)
+#   RESOURCE_BRITIVE_REMOTE_PASSWORD – WinRM password (optional, paired with user)
+#
+# Broker-supplied:
+#   BROKER_INJECTED_SCAN_OUTPUT_PATH – full path for JSON output (required)
+# ============================================================
+
+try {
+    $ErrorActionPreference = 'Stop'
+
+    if (-not $env:BROKER_INJECTED_SCAN_OUTPUT_PATH) {
+        throw "BROKER_INJECTED_SCAN_OUTPUT_PATH environment variable is not set. Cannot write scan output."
+    }
+    $outputPath = $env:BROKER_INJECTED_SCAN_OUTPUT_PATH
+
+    # ---- resolve broker-injected resource params (RESOURCE_*, plaintext) ----
+    $targetComputer = $env:RESOURCE_TARGET
+    if (-not $targetComputer) {
+        throw "Target computer not set. Provide resource param 'target' (env RESOURCE_TARGET)."
+    }
+    $remoteUser = $env:RESOURCE_BRITIVE_REMOTE_USER
+    $remotePass = $env:RESOURCE_BRITIVE_REMOTE_PASSWORD
+
+    Write-Host "Running Windows VM IAM-style broker scan against $targetComputer..."
+    Write-Host "Output path: $outputPath"
+
+    # ensure output directory exists
+    $outputDir = Split-Path -Path $outputPath -Parent
+    if ($outputDir -and -not (Test-Path $outputDir)) {
+        New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+        Write-Host "Created output directory: $outputDir"
+    }
+
+    # optional explicit credential for WinRM
+    $invokeParams = @{ ComputerName = $targetComputer }
+
+    # Fast-fail timeouts: OpenTimeout bounds the WinRM connect so an unreachable
+    # or slow target aborts in ~15s instead of hanging on the default timeouts.
+    $invokeParams.SessionOption = New-PSSessionOption -OpenTimeout 15000 -OperationTimeout 120000 -CancelTimeout 5000
+
+    if ($remoteUser -and $remotePass) {
+        $secPass = ConvertTo-SecureString $remotePass -AsPlainText -Force
+        $invokeParams.Credential = New-Object System.Management.Automation.PSCredential($remoteUser, $secPass)
+        # Basic auth: local accounts fail over Negotiate/Kerberos from a service
+        # (broker) context with error 0x8009030d. Basic forces a clean local logon.
+        # NOTE: Basic over HTTP requires WinRM 'AllowUnencrypted=true' on the target
+        # (or use HTTPS/5986). Ensure the target's WinRM service allows Basic auth.
+        $invokeParams.Authentication = 'Basic'
+        Write-Host "Using explicit credential (Basic auth) for user: $remoteUser"
+    } elseif ($remoteUser -or $remotePass) {
+        # Half-configured credential: fail fast rather than silently scanning as
+        # the broker identity, which would be a confusing wrong-context result.
+        throw "Only one of RESOURCE_BRITIVE_REMOTE_USER / RESOURCE_BRITIVE_REMOTE_PASSWORD is set. Provide both, or neither (to use the broker identity)."
+    } else {
+        Write-Host "No explicit credential provided; using broker identity."
+    }
+
+    $now = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+    # ----------------------------------------------------------
+    # Remote scan block — runs ON the target VM. Returns a single
+    # object with raw user/group records; the broker assembles the
+    # final schema so all JSON formatting happens in one place.
+    # ----------------------------------------------------------
+    $scriptBlock = {
+        $users = @()
+        foreach ($u in Get-LocalUser) {
+            $users += [PSCustomObject]@{
+                name       = $u.Name
+                enabled    = [bool]$u.Enabled
+                sid        = $u.SID.Value
+                fullname   = if ($u.FullName) { $u.FullName } else { "" }
+                desc       = if ($u.Description) { $u.Description } else { "" }
+            }
+        }
+
+        $groups = @()
+        foreach ($g in Get-LocalGroup) {
+            $members = @()
+            try {
+                Get-LocalGroupMember -Group $g.Name -ErrorAction Stop | ForEach-Object {
+                    # ObjectClass is "User" or "Group"; keep user members only,
+                    # store the short account name (strip COMPUTER\ or DOMAIN\ prefix)
+                    if ($_.ObjectClass -eq 'User') {
+                        $members += ($_.Name -split '\\')[-1]
+                    }
+                }
+            } catch {
+                # some built-in groups may deny enumeration
+            }
+            $groups += [PSCustomObject]@{
+                name    = $g.Name
+                sid     = $g.SID.Value
+                desc    = if ($g.Description) { $g.Description } else { "" }
+                members = $members
+            }
+        }
+
+        [PSCustomObject]@{
+            computer = $env:COMPUTERNAME
+            users    = $users
+            groups   = $groups
+        }
+    }
+
+    $result = Invoke-Command @invokeParams -ScriptBlock $scriptBlock
+
+    # Guard: a null/empty result means the remote block produced nothing (e.g.
+    # LocalAccounts cmdlets unavailable on an old OS). Fail so it is reported.
+    if (-not $result) {
+        throw "Remote scan against $targetComputer returned no data (target may lack Get-LocalUser/Get-LocalGroup)."
+    }
+
+    # ----------------------------------------------------------
+    # Build identities
+    # ----------------------------------------------------------
+    $identities = @()
+    foreach ($u in $result.users) {
+        $fn = "NA"; $ln = "NA"
+        if ($u.fullname) {
+            $parts = $u.fullname.Trim() -split '\s+', 2
+            $fn = $parts[0]
+            if ($parts.Count -gt 1) { $ln = $parts[1] }
+        }
+        $identities += @{
+            id          = $u.name
+            name        = $u.name
+            type        = "User"
+            description = "Local Windows user"
+            created_on  = $now
+            is_active   = [bool]$u.enabled
+            attributes  = @{
+                username    = $u.name
+                email       = "$($u.name)@$($result.computer).local"
+                sid         = $u.sid
+                first_name  = $fn
+                last_name   = $ln
+                full_name   = $u.fullname
+                user_desc   = $u.desc
+            }
+        }
+    }
+    Write-Host "Found $($identities.Count) local users."
+
+    # ----------------------------------------------------------
+    # Build groups
+    # ----------------------------------------------------------
+    $groups = @()
+    foreach ($g in $result.groups) {
+        $members = @($g.members)
+        $groups += @{
+            id          = $g.name
+            name        = $g.name
+            type        = "User group"
+            description = "Local Windows group"
+            created_on  = $now
+            is_active   = $true
+            members     = $members
+            attributes  = @{
+                groupname  = $g.name
+                sid        = $g.sid
+                group_desc = $g.desc
+            }
+        }
+    }
+    Write-Host "Found $($groups.Count) local groups."
+
+    # ----------------------------------------------------------
+    # Assemble Britive Resource Manager schema
+    # ----------------------------------------------------------
+    $output = @{
+        data = @{
+            identities         = $identities
+            groups             = $groups
+            permissions        = @()
+            permission_mapping = @()
+        }
+        metadata = @{
+            resource_id   = $result.computer
+            resource_type = "WindowsVM"
+            scan_time     = $now
+            scan_details  = "Windows VM scan completed on $($result.computer). Users: $($identities.Count), Groups: $($groups.Count)"
+            scan_errors   = ""
+            attribute_resolution = @{
+                group_membership   = "id"
+                permission_mapping = "id"
+            }
+        }
+    }
+
+    $output | ConvertTo-Json -Depth 10 | Out-File $outputPath -Encoding utf8 -Force
+    Write-Host "Windows VM broker scan completed successfully."
+    exit 0
+}
+catch {
+    Write-Host "Scan failed: $($_.Exception.Message)"
+
+    $errorOutput = @{
+        data = @{
+            groups             = @()
+            identities         = @()
+            permissions        = @()
+            permission_mapping = @()
+        }
+        metadata = @{
+            scan_errors = $_.Exception.Message
+            scan_time   = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+        }
+    }
+
+    if ($env:BROKER_INJECTED_SCAN_OUTPUT_PATH) {
+        $errorPath = $env:BROKER_INJECTED_SCAN_OUTPUT_PATH
+        $errorDir = Split-Path -Path $errorPath -Parent
+        if ($errorDir -and -not (Test-Path $errorDir)) {
+            New-Item -ItemType Directory -Path $errorDir -Force | Out-Null
+        }
+        $errorOutput | ConvertTo-Json -Depth 10 | Out-File $errorPath -Encoding utf8 -Force
+    }
+
+    exit 1
+}


### PR DESCRIPTION
- Aurora MySQL scan (mysql-scan.sh): enumerate mysql.user identities and mysql.role_edges roles/membership into the Resource Manager schema; admin creds from Secrets Manager, jq-built JSON, non-null email attribute
- Aurora MySQL rotation (rotate-mysql-user.sh): rotate a user@host account via ALTER USER; password SQL-escaped and piped over stdin (never argv/logs); verifies the account exists first
- Windows provision-cred scan variant (windows_scan_provision.ps1): reads RESOURCE_HOST / RESOURCE_PROVISION_USERNAME (default Administrator) / RESOURCE_PROVISION_PASSWORD; always Basic auth; fast-fail timeouts and null-result guard
- Harden windows_scan_script.ps1: OpenTimeout connect fast-fail, half-set credential now throws, null-result guard
- Linux scan: switch to RESOURCE_HOST / RESOURCE_USER / RESOURCE_KEY_LOCATION (legacy names kept as fallbacks); validate output is non-empty JSON before write and verify the write; skip non-numeric UID lines; hostname falls back to uname -n (Amazon Linux 2023 minimal); Ubuntu + Amazon Linux verified
- READMEs updated for all of the above