### PR TITLE
Add shell (Linux-broker) AD and Windows scan variants

### DIFF
--- a/Active Directory/scans/README.md
+++ b/Active Directory/scans/README.md
@@ -1,54 +1,90 @@
 ## Active Directory Scan
 
-This directory contains a PowerShell script that scans Active Directory for users, groups, and group memberships and outputs the data as JSON for downstream processing by the Britive Resource Manager.
+Scans Active Directory for users, groups, and group memberships and outputs JSON for the Britive Resource Manager. The output schema is identical across all scripts here (and matches the [Linux](../../Linux/scans/README.md) and [Windows](../../Windows/scans/README.md) VM scans), so the platform stores identities and groups in the same shape regardless of which script produced them.
 
-### Script: `ad-scan.ps1`
+### Scripts
 
-Connects to Active Directory, retrieves all user and group objects along with direct group membership details, and writes the results to a structured JSON file at the path specified by the Britive broker.
+| File | Runs on | Reaches AD via | Membership source |
+|---|---|---|---|
+| `ad-scan.ps1` | Windows broker | RSAT `ActiveDirectory` module | `Get-ADGroupMember` **per group** |
+| `ad-scan_2.ps1` | Windows broker | RSAT `ActiveDirectory` module | bulk group `Member` property |
+| `ad-scan.sh` | **Linux broker** | `ldapsearch` (LDAP) | inverted from each user's `memberOf` |
+
+All three produce the same `data`/`metadata` schema with `resource_type = ActiveDirectory`, `id` = `SamAccountName`, and `attribute_resolution.group_membership = "id"`.
+
+---
+
+### PowerShell variants — `ad-scan.ps1` vs `ad-scan_2.ps1`
+
+Both run on a **Windows broker** with the RSAT `ActiveDirectory` module. They differ only in **how group membership is retrieved**, which drives a correctness-vs-speed trade-off.
+
+| | `ad-scan.ps1` (per-group) | `ad-scan_2.ps1` (bulk) |
+|---|---|---|
+| Membership | `Get-ADGroupMember` for each group | `Get-ADGroup -Properties Member`, resolved against the user set |
+| Large groups (>~5000) | **Correct** — the cmdlet handles range retrieval | **Silently truncated** at AD's `MaxValRange` (~5000) |
+| AD queries | One per group (**slower** with many groups) | One bulk query (**faster**) |
+| CNF (replication-conflict) objects | Not filtered | **Skipped** |
+| Group-name sanitization | None | Strips newlines/tabs, truncates to 255 |
+| Nested / non-user members | Excluded (users only) | Excluded (only members present in the user set) |
+
+**When to use which:**
+
+- **`ad-scan.ps1`** — when **membership accuracy matters** and the domain has **large groups** (thousands of members). It won't truncate. Accept the extra per-group queries.
+- **`ad-scan_2.ps1`** — when the domain has **many groups but each is modest in size**, and scan **speed** matters. Gets CNF handling and name sanitization, but **do not use it if any group exceeds ~5000 members** — those members are dropped without error.
+- **Neither, if you can run on Linux** — prefer `ad-scan.sh` below, which avoids both weaknesses.
+
+---
+
+### Shell (Linux broker) — `ad-scan.sh`
+
+For brokers that run on Linux (no RSAT). Queries a Domain Controller over **LDAP with `ldapsearch`**; an embedded `python3` (stdlib only) parses the LDIF and assembles the JSON. Combines the strengths of both PowerShell variants:
+
+- **No large-group truncation** — membership is inverted from each **user's `memberOf`**, so it never hits the group-side ~5000 `MaxValRange` limit (a user is rarely in >1500 groups). Users' primary group (e.g. `Domain Users`) is excluded — the same as both PowerShell variants.
+- **CNF skip + name sanitization** — replication-conflict groups are skipped; group names are stripped of newlines/tabs and truncated to 255.
+- **Paged results** (default 1000/page) so directories with more than 1000 users or groups are fully enumerated.
+- **Group `id` = `sAMAccountName`** (unique per domain), avoiding the display-name collision risk of the PowerShell variants.
 
 #### Environment Variables
 
-| Variable | Required | Description |
-|---|---|---|
-| `BROKER_INJECTED_SCAN_OUTPUT_PATH` | Yes | Full file path where the scan JSON output will be written. Injected by the Britive broker at runtime. |
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `BROKER_INJECTED_SCAN_OUTPUT_PATH` | Yes | — | Full path where the scan JSON is written. Injected by the broker. |
+| `RESOURCE_HOST` | Yes | — | Domain Controller hostname / IP. |
+| `RESOURCE_USER` | Yes | — | Bind user (UPN `user@domain` or `DOMAIN\user`). |
+| `RESOURCE_PASSWORD` | Yes | — | Bind password (passed to `ldapsearch` via a `0600` file, never on the command line). |
+| `RESOURCE_BASE_DN` | No | RootDSE `defaultNamingContext` | Search base; auto-discovered from the DC if omitted. |
+| `LDAP_PROTOCOL` | No | `ldap` | `ldap` or `ldaps`. |
+| `LDAP_PORT` | No | `389` / `636` | Port (defaults by protocol). |
+| `LDAP_START_TLS` | No | `0` | `1` to issue StartTLS on a plain `ldap` connection. |
+| `PAGE_SIZE` | No | `1000` | LDAP paged-results page size. |
 
 #### How It Works
 
-1. Validates the `BROKER_INJECTED_SCAN_OUTPUT_PATH` environment variable is set (fails immediately if not).
-2. Creates the output directory if it does not exist.
-3. Imports the `ActiveDirectory` PowerShell module.
-4. Retrieves domain information for metadata.
-5. Scans all AD users and captures: email, first/last name, SamAccountName, UPN, and DistinguishedName.
-6. Scans all AD groups and captures direct (non-recursive) user members.
-7. Writes the JSON output to the broker-specified path.
-8. On failure, writes a minimal JSON with the error details so the broker can report the failure back to the platform.
-
-#### Identity Resolution
-
-- **User `id`** uses `SamAccountName` (e.g., `jdoe`). Short values that fit within database column limits.
-- **Group `id`** uses the group `Name`.
-- **Group `members`** arrays contain user `SamAccountName` values, matching the identity `id` field so that `attribute_resolution.group_membership = "id"` resolves correctly.
-- `DistinguishedName` and `UserPrincipalName` are stored in `attributes` for reference.
-
-#### Output Schema
-
-The script produces a JSON file with the following structure:
-
-- **`data.identities`** - All AD user objects with attributes: `email`, `first_name`, `last_name`, `samaccountname`, `user_principal_name`, `distinguished_name`.
-- **`data.groups`** - All AD group objects with their direct member lists (referencing identity `id` values) and attributes: `samaccountname`, `distinguished_name`.
-- **`data.permissions`** - Empty array (AD does not have separate permission/role objects).
-- **`data.permission_mapping`** - Empty array (user-to-group assignments are captured in `groups.members`).
-- **`metadata`** - Includes `resource_id` (domain DN), `resource_type`, `scan_time`, `scan_details`, `scan_errors`, and `attribute_resolution`.
-
-#### Fail-Fast Behavior
-
-- `$ErrorActionPreference = 'Stop'` ensures any non-terminating error is promoted to a terminating error.
-- Missing `BROKER_INJECTED_SCAN_OUTPUT_PATH` causes an immediate failure before any AD queries run.
-- Output directory is validated and created before the scan begins.
-- The top-level `try/catch` writes a valid error JSON so the broker always receives a parseable response.
+1. Fail-fast validation: output path, `ldapsearch`/`python3` present, `RESOURCE_HOST`/`RESOURCE_USER`/`RESOURCE_PASSWORD` set.
+2. Auto-discovers the base DN from RootDSE (`defaultNamingContext`) unless `RESOURCE_BASE_DN` is given — this first query also serves as the bind/connectivity test.
+3. Queries **users** (`(&(objectCategory=person)(objectClass=user))`) for `sAMAccountName`, `mail`, `givenName`, `sn`, `userPrincipalName`, `userAccountControl`, `memberOf`.
+4. Queries **groups** (`(objectClass=group)`) for `sAMAccountName`, `cn`, `name`.
+5. Builds identities (`is_active` from the `userAccountControl` `ACCOUNTDISABLE` bit; non-null `email` = `mail` or `<sam>@<domain>`), inverts `memberOf` into per-group member lists, and enumerates all groups (empty ones included).
+6. Validates the assembled output is non-empty JSON, then writes it; verifies the write succeeds.
+7. On any failure — bind/connect, query, parse, or write — writes a valid error JSON with the message so the broker reports it back.
 
 #### Prerequisites
 
-- Windows PowerShell 5.1 or later
-- RSAT Active Directory module installed (see [parent README](../README.md) for installation instructions)
-- Appropriate permissions to read AD user and group objects
+- **Broker host (Linux):** `sh`, `ldapsearch` (openldap-clients), `python3`, `sed`, `mktemp`; network reachability to the DC (LDAP 389 / LDAPS 636).
+- **Directory:** the bind account able to read user and group objects. Plain `ldap` sends the bind password in cleartext — prefer `ldaps` or `LDAP_START_TLS=1` in production.
+
+---
+
+### Shared: Identity Resolution & Output Schema
+
+- **User `id`** = `SamAccountName` (short, fits `native_id` limits). **Group `id`** = the group name (PowerShell variants) or `sAMAccountName` (shell).
+- **Group `members`** contain user `SamAccountName` values matching identity `id`s, so `attribute_resolution.group_membership = "id"` resolves.
+- **`data.identities`** — users with attributes: `email` (non-null), `first_name`, `last_name`, `samaccountname`, `user_principal_name`, `distinguished_name`.
+- **`data.groups`** — groups with user member lists and attributes: `samaccountname`, `distinguished_name`.
+- **`data.permissions`** / **`data.permission_mapping`** — empty (AD has no separate permission objects; user-to-group lives in `groups.members`).
+- **`metadata`** — `resource_id` (domain/base DN), `resource_type` = `ActiveDirectory`, `scan_time`, `scan_details`, `scan_errors`, `attribute_resolution`.
+
+#### Fail-Fast (all scripts)
+
+- PowerShell: `$ErrorActionPreference = 'Stop'`; missing output path or AD module fails before scanning; top-level `try/catch` writes a valid error JSON.
+- Shell: validates commands + inputs before binding; the RootDSE query doubles as the bind test; empty/non-JSON output and write failures each produce a valid error JSON.

--- a/Active Directory/scans/ad-scan.sh
+++ b/Active Directory/scans/ad-scan.sh
@@ -1,0 +1,288 @@
+#!/bin/sh
+set -eu
+
+# ============================================================
+# Active Directory IAM-Style Broker Scan (runs on the Linux broker)
+# ============================================================
+# Shell version of the ad-scan PowerShell scripts. Instead of the
+# RSAT ActiveDirectory module on a Windows broker, this runs on a
+# Linux broker and queries a Domain Controller over LDAP with
+# `ldapsearch`. An embedded python3 (stdlib only) parses the LDIF
+# and emits the Britive Resource Manager JSON; the broker captures,
+# validates, and writes it.
+#
+# Best of both PowerShell variants:
+#   - Group membership is inverted from each user's memberOf, so it
+#     is NOT subject to the group-side ~5000 range truncation that
+#     bulk Member retrieval hits (the ad-scan_2.ps1 weakness), while
+#     still resolving user members only (both variants' behavior).
+#   - CNF (replication-conflict) groups are skipped and group names
+#     are sanitized/truncated (the ad-scan_2.ps1 strengths).
+#   - Paged results (default 1000/page) so directories with >1000
+#     users or groups are fully enumerated.
+#
+# Broker-injected resource params (plaintext env vars):
+#   RESOURCE_HOST      – Domain Controller hostname/IP            (required)
+#   RESOURCE_USER      – bind user (UPN user@domain or DOMAIN\\user) (required)
+#   RESOURCE_PASSWORD  – bind password                            (required)
+#
+# Broker-supplied:
+#   BROKER_INJECTED_SCAN_OUTPUT_PATH – full path for JSON output  (required)
+#
+# Optional:
+#   RESOURCE_BASE_DN   – search base (default: RootDSE defaultNamingContext)
+#   LDAP_PROTOCOL      – ldap (default) or ldaps
+#   LDAP_PORT          – default 389 (ldap) / 636 (ldaps)
+#   LDAP_START_TLS     – 1 to issue StartTLS on a plain ldap connection (default 0)
+#   PAGE_SIZE          – LDAP paged-results page size (default 1000)
+#
+# NOTE: plain ldap sends the bind password in cleartext — prefer
+# ldaps or LDAP_START_TLS=1 in production. The password is passed to
+# ldapsearch via a 0600 file (never on the command line).
+# ============================================================
+
+# ---- broker-side validation -------------------------------
+if [ -z "${BROKER_INJECTED_SCAN_OUTPUT_PATH:-}" ]; then
+    echo "ERROR: BROKER_INJECTED_SCAN_OUTPUT_PATH not set. Cannot write scan output." >&2
+    exit 1
+fi
+OUTPUT_PATH="$BROKER_INJECTED_SCAN_OUTPUT_PATH"
+
+DC_HOST="${RESOURCE_HOST:-}"
+BIND_USER="${RESOURCE_USER:-}"
+BIND_PASS="${RESOURCE_PASSWORD:-}"
+BASE_DN="${RESOURCE_BASE_DN:-}"
+LDAP_PROTOCOL="${LDAP_PROTOCOL:-ldap}"
+LDAP_START_TLS="${LDAP_START_TLS:-0}"
+PAGE_SIZE="${PAGE_SIZE:-1000}"
+
+if [ "$LDAP_PROTOCOL" = "ldaps" ]; then
+    LDAP_PORT="${LDAP_PORT:-636}"
+else
+    LDAP_PORT="${LDAP_PORT:-389}"
+fi
+LDAP_URI="${LDAP_PROTOCOL}://${DC_HOST}:${LDAP_PORT}"
+
+OUT_DIR="$(dirname "$OUTPUT_PATH")"
+[ -d "$OUT_DIR" ] || mkdir -p "$OUT_DIR"
+
+# ---- error JSON helper ------------------------------------
+# write_error <message>
+write_error() {
+    _msg="$1"
+    _now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    _msg_esc="$(printf '%s' "$_msg" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
+    cat > "$OUTPUT_PATH" <<EOF
+{
+  "data": { "identities": [], "groups": [], "permissions": [], "permission_mapping": [] },
+  "metadata": { "scan_errors": "$_msg_esc", "scan_time": "$_now" }
+}
+EOF
+}
+
+# ---- fail-fast checks -------------------------------------
+command -v ldapsearch >/dev/null 2>&1 || { write_error "ldapsearch not found on broker (install openldap-clients)"; echo "ERROR: ldapsearch not found" >&2; exit 1; }
+command -v python3   >/dev/null 2>&1 || { write_error "python3 not found on broker"; echo "ERROR: python3 not found" >&2; exit 1; }
+[ -n "$DC_HOST" ]   || { write_error "RESOURCE_HOST empty"; echo "ERROR: RESOURCE_HOST empty" >&2; exit 1; }
+[ -n "$BIND_USER" ] || { write_error "RESOURCE_USER empty"; echo "ERROR: RESOURCE_USER empty" >&2; exit 1; }
+[ -n "$BIND_PASS" ] || { write_error "RESOURCE_PASSWORD empty"; echo "ERROR: RESOURCE_PASSWORD empty" >&2; exit 1; }
+
+echo "Running AD IAM-style broker scan against $LDAP_URI ..." >&2
+echo "Output path: $OUTPUT_PATH" >&2
+
+# ---- temp files & cleanup ---------------------------------
+PW_FILE="$(mktemp)"
+USERS_LDIF="$(mktemp)"
+GROUPS_LDIF="$(mktemp)"
+TMP_ERR="$(mktemp)"
+TMP_OUT="$(mktemp)"
+chmod 600 "$PW_FILE" "$USERS_LDIF" "$GROUPS_LDIF"
+trap 'rm -f "$PW_FILE" "$USERS_LDIF" "$GROUPS_LDIF" "$TMP_ERR" "$TMP_OUT"' EXIT INT TERM
+umask 077
+
+printf '%s' "$BIND_PASS" > "$PW_FILE"
+
+# StartTLS flag for plain ldap connections
+TLS_FLAG=""
+[ "$LDAP_PROTOCOL" = "ldap" ] && [ "$LDAP_START_TLS" = "1" ] && TLS_FLAG="-ZZ"
+
+# common ldapsearch args: simple bind, password from file, no line wrap,
+# attrs-and-values only, paged results, referrals off (AD chases them badly)
+# shellcheck disable=SC2086
+ldap_query() {
+    _base="$1"; _scope="$2"; _filter="$3"; shift 3
+    ldapsearch -x -o ldif-wrap=no -LLL $TLS_FLAG \
+        -H "$LDAP_URI" \
+        -D "$BIND_USER" -y "$PW_FILE" \
+        -E "pr=${PAGE_SIZE}/noprompt" \
+        -o referrals=no \
+        -s "$_scope" -b "$_base" \
+        "$_filter" "$@"
+}
+
+# ---- resolve base DN via RootDSE if not provided ----------
+if [ -z "$BASE_DN" ]; then
+    if ! ldap_query "" base "(objectClass=*)" defaultNamingContext > "$TMP_OUT" 2>"$TMP_ERR"; then
+        write_error "LDAP bind/connect failed: $(cat "$TMP_ERR")"
+        echo "ERROR: LDAP bind failed" >&2
+        exit 1
+    fi
+    BASE_DN="$(sed -n 's/^defaultNamingContext: //p' "$TMP_OUT" | head -n 1)"
+    [ -n "$BASE_DN" ] || { write_error "could not determine base DN from RootDSE (set RESOURCE_BASE_DN)"; echo "ERROR: no base DN" >&2; exit 1; }
+    echo "Discovered base DN: $BASE_DN" >&2
+fi
+
+# ---- query users and groups -------------------------------
+# Users: memberOf is used to invert group membership (avoids group-side range).
+if ! ldap_query "$BASE_DN" sub "(&(objectCategory=person)(objectClass=user))" \
+        sAMAccountName mail givenName sn userPrincipalName userAccountControl memberOf \
+        > "$USERS_LDIF" 2>"$TMP_ERR"; then
+    write_error "user query failed: $(cat "$TMP_ERR")"
+    echo "ERROR: user query failed" >&2
+    exit 1
+fi
+
+if ! ldap_query "$BASE_DN" sub "(objectClass=group)" \
+        sAMAccountName cn name \
+        > "$GROUPS_LDIF" 2>"$TMP_ERR"; then
+    write_error "group query failed: $(cat "$TMP_ERR")"
+    echo "ERROR: group query failed" >&2
+    exit 1
+fi
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# ---- parse LDIF and assemble Britive JSON (python3 stdlib) ----
+if ! BASE_DN="$BASE_DN" NOW="$NOW" USERS_LDIF="$USERS_LDIF" GROUPS_LDIF="$GROUPS_LDIF" \
+    python3 - > "$TMP_OUT" 2>"$TMP_ERR" <<'PYEOF'
+import os, re, sys, json, base64
+
+def parse_ldif(path):
+    entries, cur = [], None
+    with open(path, 'r', encoding='utf-8', errors='replace') as f:
+        for raw in f:
+            line = raw.rstrip('\n').rstrip('\r')
+            if line == '':
+                if cur is not None:
+                    entries.append(cur); cur = None
+                continue
+            if line.startswith('#'):
+                continue
+            m = re.match(r'^([^:]+)(::?)[ ]?(.*)$', line)
+            if not m:
+                continue
+            attr, sep, val = m.group(1), m.group(2), m.group(3)
+            if sep == '::':
+                try:
+                    val = base64.b64decode(val).decode('utf-8', 'replace')
+                except Exception:
+                    pass
+            if cur is None:
+                cur = {}
+            cur.setdefault(attr, []).append(val)
+    if cur is not None:
+        entries.append(cur)
+    return entries
+
+def first(e, k, default=''):
+    v = e.get(k)
+    return v[0] if v else default
+
+base_dn = os.environ['BASE_DN']
+now     = os.environ['NOW']
+domain  = '.'.join(re.findall(r'DC=([^,]+)', base_dn, re.I)) or 'ad.local'
+
+users  = parse_ldif(os.environ['USERS_LDIF'])
+groups = parse_ldif(os.environ['GROUPS_LDIF'])
+
+# invert membership from each user's memberOf: group DN (lowercased) -> {sam}
+membership = {}
+identities = []
+for u in users:
+    sam = first(u, 'sAMAccountName')
+    if not sam:
+        continue
+    uac = first(u, 'userAccountControl', '0')
+    try:
+        disabled = bool(int(uac) & 0x2)   # ACCOUNTDISABLE
+    except ValueError:
+        disabled = False
+    mail = first(u, 'mail') or (sam + '@' + domain)   # email must be non-null
+    identities.append({
+        'id': sam, 'name': sam, 'type': 'User',
+        'description': 'Active Directory user', 'created_on': now,
+        'is_active': (not disabled),
+        'attributes': {
+            'email': mail,
+            'first_name': first(u, 'givenName') or 'NA',
+            'last_name': first(u, 'sn') or 'NA',
+            'samaccountname': sam,
+            'user_principal_name': first(u, 'userPrincipalName'),
+            'distinguished_name': first(u, 'dn'),
+        },
+    })
+    for gdn in u.get('memberOf', []):
+        membership.setdefault(gdn.lower(), set()).add(sam)
+
+groups_out = []
+cnf_skipped = 0
+for g in groups:
+    dn = first(g, 'dn')
+    name = first(g, 'cn') or first(g, 'name') or first(g, 'sAMAccountName')
+    # skip replication-conflict (CNF) objects
+    if 'CNF:' in dn or 'CNF:' in name:
+        cnf_skipped += 1
+        continue
+    name = re.sub(r'[\r\n\t]', ' ', name).strip()[:255]
+    gsam = first(g, 'sAMAccountName') or name
+    members = sorted(membership.get(dn.lower(), set()))
+    groups_out.append({
+        'id': gsam, 'name': name, 'type': 'User group',
+        'description': 'Active Directory group', 'created_on': now,
+        'is_active': True, 'members': members,
+        'attributes': {'samaccountname': gsam, 'distinguished_name': dn},
+    })
+
+out = {
+    'data': {
+        'identities': identities,
+        'groups': groups_out,
+        'permissions': [],
+        'permission_mapping': [],
+    },
+    'metadata': {
+        'resource_id': base_dn,
+        'resource_type': 'ActiveDirectory',
+        'scan_time': now,
+        'scan_details': 'AD scan completed. Users: %d, Groups: %d, CNF skipped: %d'
+                        % (len(identities), len(groups_out), cnf_skipped),
+        'scan_errors': '',
+        'attribute_resolution': {'group_membership': 'id', 'permission_mapping': 'id'},
+    },
+}
+json.dump(out, sys.stdout)
+PYEOF
+then
+    write_error "failed to assemble scan JSON: $(cat "$TMP_ERR")"
+    echo "ERROR: JSON assembly failed: $(cat "$TMP_ERR")" >&2
+    exit 1
+fi
+
+# ---- validate and write -----------------------------------
+if [ ! -s "$TMP_OUT" ]; then
+    write_error "scan produced no output"
+    echo "ERROR: empty scan output" >&2
+    exit 1
+fi
+case "$(head -c 1 "$TMP_OUT")" in
+    '{') : ;;
+    *) write_error "scan produced non-JSON output"; echo "ERROR: non-JSON output" >&2; exit 1 ;;
+esac
+
+if ! cat "$TMP_OUT" > "$OUTPUT_PATH"; then
+    echo "ERROR: failed to write scan output to $OUTPUT_PATH" >&2
+    exit 1
+fi
+
+echo "AD broker scan completed successfully." >&2
+exit 0

--- a/Active Directory/scans/ad-scan_2.ps1
+++ b/Active Directory/scans/ad-scan_2.ps1
@@ -1,5 +1,5 @@
 # ============================================================
-# Active Directory IAM-Style Broker Scan – Optimised v3
+# Active Directory IAM-Style Broker Scan – Optimized v3
 # ============================================================
 # Required env var:
 #   BROKER_INJECTED_SCAN_OUTPUT_PATH

--- a/Windows/scans/README.md
+++ b/Windows/scans/README.md
@@ -1,19 +1,31 @@
 ## Windows VM Scan
 
-This directory contains a PowerShell script that scans a remote Windows VM for its **local** users, groups, and group memberships and outputs the data as JSON for downstream processing by the Britive Resource Manager. The output schema is identical to the [Active Directory scan](../../Active%20Directory/scans/README.md) so the Britive platform stores local identities and groups per VM in the same shape.
+This directory scans a remote Windows VM for its **local** users, groups, and group memberships and outputs JSON for the Britive Resource Manager. The output schema is identical to the [Active Directory](../../Active%20Directory/scans/README.md) and [Linux](../../Linux/scans/README.md) scans so the platform stores local identities and groups per VM in the same shape.
 
-### Script: `windows-scan.ps1`
+### Scripts
 
-Runs on the Britive broker. It connects to a target Windows VM over WinRM via `Invoke-Command` (the same remote pattern as the [local-admin-remote-server](../permissions/local-admin-remote-server/README.md) checkout/checkin scripts), enumerates local accounts **on the VM**, then assembles the final JSON on the broker and writes it to the broker-specified path.
+| File | Runs on | Reaches the target via | Notes |
+|---|---|---|---|
+| `windows_scan_script.ps1` | Windows broker | PowerShell remoting (`Invoke-Command`) | Optional explicit credential; falls back to broker identity |
+| `windows_scan_provision.ps1` | Windows broker | PowerShell remoting (`Invoke-Command`) | Provision credential **required** (`RESOURCE_PROVISION_*`) |
+| `windows-scan.sh` | **Linux broker** | WinRM (pywinrm) or SSH (`powershell.exe -EncodedCommand`) | Shell version; same transport as the [temp-rdp-bridge](../permissions/temp-rdp-bridge/) scripts |
+
+All three run a PowerShell enumeration on the VM (`Get-LocalUser`, `Get-LocalGroup`, `Get-LocalGroupMember`) and produce the same `data`/`metadata` schema with `resource_type = WindowsVM`.
+
+### PowerShell: `windows_scan_provision.ps1`
+
+Runs on a Windows broker; connects to the target over WinRM via `Invoke-Command`, enumerates local accounts **on the VM**, assembles the JSON on the broker, and writes it to the broker-specified path.
 
 #### Environment Variables
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `BROKER_INJECTED_SCAN_OUTPUT_PATH` | Yes | — | Full file path where the scan JSON is written. Injected by the broker at runtime. |
-| `target` (or `BRITIVE_REMOTE_HOST`) | Yes | — | Target VM hostname / IP. |
-| `BRITIVE_REMOTE_USER` | No | — | WinRM user. Omit to use the broker's own identity (Kerberos/integrated). |
-| `BRITIVE_REMOTE_PASSWORD` | No | — | WinRM password, paired with `BRITIVE_REMOTE_USER`. |
+| `RESOURCE_HOST` | Yes | — | Target VM hostname / IP. |
+| `RESOURCE_PROVISION_USERNAME` | No | `Administrator` | WinRM admin user. |
+| `RESOURCE_PROVISION_PASSWORD` | Yes | — | WinRM admin password (Basic auth). |
+
+(The `windows_scan_script.ps1` variant instead uses `RESOURCE_TARGET` + optional `RESOURCE_BRITIVE_REMOTE_USER`/`_PASSWORD`, falling back to the broker identity when omitted.)
 
 #### How It Works
 
@@ -51,3 +63,35 @@ Runs on the Britive broker. It connects to a target Windows VM over WinRM via `I
 
 - **Broker host:** Windows PowerShell 5.1+ with WinRM client; network reachability to the VM (WinRM 5985/5986).
 - **Target VM:** WinRM enabled (`Enable-PSRemoting`); the connecting account in the local Administrators group (or granted rights to `Get-LocalUser`/`Get-LocalGroup`/`Get-LocalGroupMember`); `Microsoft.PowerShell.LocalAccounts` module (built in on Windows 10/Server 2016+).
+
+---
+
+### Shell (Linux broker): `windows-scan.sh`
+
+For brokers that run on Linux. Reaches the Windows target exactly like the [temp-rdp-bridge](../permissions/temp-rdp-bridge/) checkout scripts — WinRM via `python3` + `pywinrm`, or SSH via `powershell.exe -EncodedCommand`. A PowerShell block runs **on the target**, enumerates local users/groups, and emits the full Britive JSON on stdout; the broker captures it, normalizes line endings / BOM, validates it, and writes it to the output path.
+
+#### Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `BROKER_INJECTED_SCAN_OUTPUT_PATH` | Yes | — | Full file path where the scan JSON is written. Injected by the broker. |
+| `RESOURCE_HOST` | Yes | — | Target VM hostname / IP. |
+| `RESOURCE_PROVISION_USERNAME` | No | `Administrator` | WinRM/SSH admin user. |
+| `RESOURCE_PROVISION_PASSWORD` | Yes (winrm) | — | Admin password. Required for the `winrm` transport. |
+| `PROVISION_TRANSPORT` | No | `winrm` | `winrm` or `ssh`. |
+| `PROVISION_HOST` | No | `RESOURCE_HOST` | Host to connect to, if different from the target. |
+| `PROVISION_PORT` | No | `5985`/`5986` (winrm), `22` (ssh) | Connection port. |
+| `WINRM_NO_SSL` | No | `1` | `1` = HTTP/5985, `0` = HTTPS/5986. |
+| `PROVISION_KEY` | No | `/home/bridge/.ssh/id_ed25519` | SSH private key path (ssh transport). |
+| `PROVISION_KEY_PEM` | No | — | Inline PEM SSH key (preferred; written to tmpfs). |
+
+#### Error Handling / Fast-Fail
+
+- Fails fast on a missing output path, `RESOURCE_HOST`, an invalid `PROVISION_TRANSPORT`, missing `python3`/`pywinrm`/`ssh`, a missing winrm password, or a missing SSH key — all before connecting.
+- WinRM uses bounded read/operation timeouts; SSH uses `ConnectTimeout=10` + `BatchMode=yes`.
+- After the remote call: strips CRLF/BOM, then rejects **empty** output, a `PSERROR: ...` line (remote PowerShell error), or **non-JSON** output — writing a valid error JSON in each case. The final write to the broker path is verified.
+
+#### Prerequisites
+
+- **Broker host (Linux):** `sh`, `python3` (+ `pywinrm` for the winrm transport: `pip install pywinrm`), `ssh` (for the ssh transport), `sed`, `mktemp`; network reachability to the VM (WinRM 5985/5986 or SSH 22).
+- **Target VM:** WinRM enabled with the chosen auth (NTLM/Basic; Basic over HTTP requires `AllowUnencrypted=true`), **or** Windows OpenSSH server; the admin account able to run `Get-LocalUser`/`Get-LocalGroup`/`Get-LocalGroupMember`.

--- a/Windows/scans/windows-scan.sh
+++ b/Windows/scans/windows-scan.sh
@@ -1,0 +1,322 @@
+#!/bin/sh
+set -eu
+
+# ============================================================
+# Windows VM IAM-Style Broker Scan (runs on the Linux broker)
+# ============================================================
+# Shell version of windows_scan_provision.ps1. Instead of PowerShell
+# remoting from a Windows broker, this runs on the Linux broker and
+# reaches the Windows target the same way the temp-rdp-bridge scripts
+# do — WinRM (python3 + pywinrm) or SSH (powershell.exe -EncodedCommand).
+#
+# A PowerShell block runs ON the target, enumerates local users and
+# groups, and emits the Britive Resource Manager JSON on stdout. The
+# broker captures it, validates it, and writes it to the output path.
+#
+# Broker-injected resource params (plaintext env vars):
+#   RESOURCE_HOST                 – target VM hostname/IP        (required)
+#   RESOURCE_PROVISION_USERNAME   – WinRM/SSH admin user         (default: Administrator)
+#   RESOURCE_PROVISION_PASSWORD   – admin password (required for winrm)
+#
+# Broker-supplied:
+#   BROKER_INJECTED_SCAN_OUTPUT_PATH – full path for JSON output (required)
+#
+# Optional:
+#   PROVISION_TRANSPORT – winrm (default) or ssh
+#   PROVISION_HOST      – host to connect to (default: RESOURCE_HOST)
+#   PROVISION_PORT      – default 5985/5986 (winrm) or 22 (ssh)
+#   WINRM_NO_SSL        – 1 for HTTP/5985 (default: 1), 0 for HTTPS/5986
+#   PROVISION_KEY       – SSH private key path (default: /home/bridge/.ssh/id_ed25519)
+#   PROVISION_KEY_PEM   – inline PEM content of the SSH key (preferred; tmpfs)
+#
+# Basic/NTLM over HTTP requires WinRM 'AllowUnencrypted=true' on the
+# target (or use HTTPS/5986).
+# ============================================================
+
+# ---- broker-side validation -------------------------------
+if [ -z "${BROKER_INJECTED_SCAN_OUTPUT_PATH:-}" ]; then
+    echo "ERROR: BROKER_INJECTED_SCAN_OUTPUT_PATH not set. Cannot write scan output." >&2
+    exit 1
+fi
+OUTPUT_PATH="$BROKER_INJECTED_SCAN_OUTPUT_PATH"
+
+TARGET_HOST="${RESOURCE_HOST:-}"
+PROVISION_USER="${RESOURCE_PROVISION_USERNAME:-Administrator}"
+PROVISION_PASSWORD="${RESOURCE_PROVISION_PASSWORD:-}"
+PROVISION_TRANSPORT="${PROVISION_TRANSPORT:-winrm}"
+PROVISION_HOST="${PROVISION_HOST:-${TARGET_HOST}}"
+PROVISION_KEY="${PROVISION_KEY:-/home/bridge/.ssh/id_ed25519}"
+PROVISION_KEY_PEM="${PROVISION_KEY_PEM:-}"
+WINRM_NO_SSL="${WINRM_NO_SSL:-1}"
+
+if [ "$PROVISION_TRANSPORT" = "winrm" ]; then
+    if [ "$WINRM_NO_SSL" = "1" ]; then
+        PROVISION_PORT="${PROVISION_PORT:-5985}"
+    else
+        PROVISION_PORT="${PROVISION_PORT:-5986}"
+    fi
+else
+    PROVISION_PORT="${PROVISION_PORT:-22}"
+fi
+
+OUT_DIR="$(dirname "$OUTPUT_PATH")"
+[ -d "$OUT_DIR" ] || mkdir -p "$OUT_DIR"
+
+# ---- error JSON helper ------------------------------------
+# write_error <message>
+write_error() {
+    _msg="$1"
+    _now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    _msg_esc="$(printf '%s' "$_msg" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
+    cat > "$OUTPUT_PATH" <<EOF
+{
+  "data": { "identities": [], "groups": [], "permissions": [], "permission_mapping": [] },
+  "metadata": { "scan_errors": "$_msg_esc", "scan_time": "$_now" }
+}
+EOF
+}
+
+# ---- fail-fast checks -------------------------------------
+[ -n "$TARGET_HOST" ] || { write_error "RESOURCE_HOST empty"; echo "ERROR: RESOURCE_HOST empty" >&2; exit 1; }
+
+case "$PROVISION_TRANSPORT" in
+    winrm)
+        command -v python3 >/dev/null 2>&1 || { write_error "python3 not found on broker"; echo "ERROR: python3 not found" >&2; exit 1; }
+        python3 -c "import winrm" 2>/dev/null || { write_error "pywinrm not installed (pip install pywinrm)"; echo "ERROR: pywinrm not installed" >&2; exit 1; }
+        [ -n "$PROVISION_PASSWORD" ] || { write_error "RESOURCE_PROVISION_PASSWORD required for winrm transport"; echo "ERROR: password required for winrm" >&2; exit 1; }
+        ;;
+    ssh)
+        command -v ssh >/dev/null 2>&1 || { write_error "ssh not found on broker"; echo "ERROR: ssh not found" >&2; exit 1; }
+        [ -n "$PROVISION_KEY_PEM" ] || [ -f "$PROVISION_KEY" ] || { write_error "ssh transport requires PROVISION_KEY_PEM or key at $PROVISION_KEY"; echo "ERROR: ssh key missing" >&2; exit 1; }
+        command -v python3 >/dev/null 2>&1 || { write_error "python3 required to base64-encode the PowerShell command"; echo "ERROR: python3 not found" >&2; exit 1; }
+        ;;
+    *) write_error "PROVISION_TRANSPORT must be 'winrm' or 'ssh' (got: $PROVISION_TRANSPORT)"; echo "ERROR: bad transport" >&2; exit 1 ;;
+esac
+
+echo "Running Windows VM broker scan against $TARGET_HOST via $PROVISION_TRANSPORT..." >&2
+echo "Output path: $OUTPUT_PATH" >&2
+
+# ---- temp files & cleanup ---------------------------------
+TMP_OUT="$(mktemp)"
+TMP_ERR="$(mktemp)"
+PS_FILE=""
+KEY_FILE=""
+trap 'rm -f "$TMP_OUT" "$TMP_ERR" ${PS_FILE:+"$PS_FILE"} ${KEY_FILE:+"$KEY_FILE"}' EXIT INT TERM
+umask 077
+
+if [ "$PROVISION_TRANSPORT" = "ssh" ] && [ -n "$PROVISION_KEY_PEM" ]; then
+    KEY_FILE="$(mktemp -p /dev/shm 2>/dev/null || mktemp)"
+    printf '%s\n' "$PROVISION_KEY_PEM" > "$KEY_FILE"
+    chmod 600 "$KEY_FILE"
+    PROVISION_KEY="$KEY_FILE"
+fi
+
+# ---- PowerShell scan block (runs ON the target) -----------
+# Enumerates local users/groups and emits the Britive Resource Manager
+# JSON on stdout. Emits ONLY the JSON (or 'PSERROR: ...' on failure) so
+# the broker can capture it cleanly.
+PS_SCAN="$(cat <<'PS_EOF'
+$ProgressPreference = 'SilentlyContinue'
+$ErrorActionPreference = 'Stop'
+try {
+    $now      = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $computer = $env:COMPUTERNAME
+
+    $identities = @()
+    foreach ($u in Get-LocalUser) {
+        $fn = "NA"; $ln = "NA"
+        if ($u.FullName) {
+            $parts = $u.FullName.Trim() -split '\s+', 2
+            $fn = $parts[0]
+            if ($parts.Count -gt 1) { $ln = $parts[1] }
+        }
+        $identities += @{
+            id          = $u.Name
+            name        = $u.Name
+            type        = "User"
+            description = "Local Windows user"
+            created_on  = $now
+            is_active   = [bool]$u.Enabled
+            attributes  = @{
+                username   = $u.Name
+                email      = "$($u.Name)@$computer.local"
+                sid        = $u.SID.Value
+                first_name = $fn
+                last_name  = $ln
+                full_name  = if ($u.FullName) { $u.FullName } else { "" }
+                user_desc  = if ($u.Description) { $u.Description } else { "" }
+            }
+        }
+    }
+
+    $groups = @()
+    foreach ($g in Get-LocalGroup) {
+        $members = @()
+        try {
+            Get-LocalGroupMember -Group $g.Name -ErrorAction Stop | ForEach-Object {
+                if ($_.ObjectClass -eq 'User') { $members += ($_.Name -split '\\')[-1] }
+            }
+        } catch {
+            # some built-in groups may deny enumeration
+        }
+        $groups += @{
+            id          = $g.Name
+            name        = $g.Name
+            type        = "User group"
+            description = "Local Windows group"
+            created_on  = $now
+            is_active   = $true
+            members     = $members
+            attributes  = @{
+                groupname  = $g.Name
+                sid        = $g.SID.Value
+                group_desc = if ($g.Description) { $g.Description } else { "" }
+            }
+        }
+    }
+
+    $output = @{
+        data = @{
+            identities         = $identities
+            groups             = $groups
+            permissions        = @()
+            permission_mapping = @()
+        }
+        metadata = @{
+            resource_id   = $computer
+            resource_type = "WindowsVM"
+            scan_time     = $now
+            scan_details  = "Windows VM scan completed on $computer. Users: $($identities.Count), Groups: $($groups.Count)"
+            scan_errors   = ""
+            attribute_resolution = @{
+                group_membership   = "id"
+                permission_mapping = "id"
+            }
+        }
+    }
+
+    $output | ConvertTo-Json -Depth 10
+} catch {
+    Write-Output ('PSERROR: ' + $_.Exception.Message)
+    exit 1
+}
+PS_EOF
+)"
+
+# ---- run the scan on the target, capture JSON on stdout ----
+set +e
+case "$PROVISION_TRANSPORT" in
+    winrm)
+        PS_FILE="$(mktemp)"
+        printf '%s' "$PS_SCAN" > "$PS_FILE"
+
+        WINRM_SCHEME="https"
+        [ "$WINRM_NO_SSL" = "1" ] && WINRM_SCHEME="http"
+
+        PROVISION_HOST="$PROVISION_HOST" \
+        PROVISION_USER="$PROVISION_USER" \
+        PROVISION_PASSWORD="$PROVISION_PASSWORD" \
+        PROVISION_PORT="$PROVISION_PORT" \
+        WINRM_SCHEME="$WINRM_SCHEME" \
+        PS_FILE="$PS_FILE" \
+        python3 - > "$TMP_OUT" 2> "$TMP_ERR" <<'PYEOF'
+import os, sys
+
+try:
+    import winrm
+except ImportError:
+    sys.stderr.write("pywinrm not installed\n")
+    sys.exit(1)
+
+host     = os.environ['PROVISION_HOST']
+user     = os.environ['PROVISION_USER']
+password = os.environ['PROVISION_PASSWORD']
+port     = int(os.environ.get('PROVISION_PORT', '5985'))
+scheme   = os.environ.get('WINRM_SCHEME', 'http')
+
+with open(os.environ['PS_FILE']) as f:
+    script = f.read()
+
+try:
+    session = winrm.Session(
+        target='{}://{}:{}/wsman'.format(scheme, host, port),
+        auth=(user, password),
+        transport='ntlm',
+        server_cert_validation='ignore',
+        read_timeout_sec=70,
+        operation_timeout_sec=60,
+    )
+    result = session.run_ps(script)
+except Exception as e:
+    sys.stderr.write('WinRM error: {}\n'.format(e))
+    sys.exit(1)
+
+out = result.std_out.decode('utf-8', 'replace')
+err = result.std_err.decode('utf-8', 'replace').strip()
+
+if result.status_code != 0:
+    sys.stderr.write('PS failed (status={}): {} {}\n'.format(result.status_code, out.strip(), err))
+    sys.exit(1)
+
+# emit ONLY the PowerShell stdout (the JSON) so the broker can capture it
+sys.stdout.write(out)
+PYEOF
+        ;;
+    ssh)
+        ENCODED="$(printf '%s' "$PS_SCAN" | \
+            python3 -c 'import sys, base64; print(base64.b64encode(sys.stdin.read().encode("utf-16-le")).decode())')"
+        ssh -i "$PROVISION_KEY" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            -o ConnectTimeout=10 \
+            -o BatchMode=yes \
+            -p "$PROVISION_PORT" \
+            "${PROVISION_USER}@${PROVISION_HOST}" \
+            "powershell.exe -NonInteractive -EncodedCommand ${ENCODED}" > "$TMP_OUT" 2> "$TMP_ERR"
+        ;;
+esac
+RC=$?
+set -e
+
+# ---- transport / remote failure ---------------------------
+if [ "$RC" -ne 0 ]; then
+    ERRMSG="$(cat "$TMP_ERR")"
+    [ -z "$ERRMSG" ] && ERRMSG="Remote scan failed with exit code $RC"
+    echo "Scan failed: $ERRMSG" >&2
+    write_error "$ERRMSG"
+    exit 1
+fi
+
+# ---- normalize and validate captured output --------------
+# PowerShell over SSH/WinRM may emit CRLF and a leading UTF-8 BOM; strip both
+# so the result is clean JSON.
+sed -e '1s/^\xEF\xBB\xBF//' -e 's/\r$//' "$TMP_OUT" > "$TMP_OUT.clean" && mv "$TMP_OUT.clean" "$TMP_OUT"
+
+if [ ! -s "$TMP_OUT" ]; then
+    write_error "Remote scan returned no output (stderr: $(cat "$TMP_ERR"))"
+    echo "ERROR: empty scan output" >&2
+    exit 1
+fi
+
+# a PowerShell error surfaces as 'PSERROR: ...' on stdout
+if head -n 1 "$TMP_OUT" | grep -q '^PSERROR:'; then
+    ERRMSG="$(cat "$TMP_OUT")"
+    echo "Scan failed: $ERRMSG" >&2
+    write_error "$ERRMSG"
+    exit 1
+fi
+
+# must be a JSON object
+case "$(sed -e 's/^[[:space:]]*//' "$TMP_OUT" | head -c 1)" in
+    '{') : ;;
+    *) write_error "Remote scan produced non-JSON output"; echo "ERROR: non-JSON output" >&2; exit 1 ;;
+esac
+
+# ---- write the JSON to the broker output path -------------
+if ! cat "$TMP_OUT" > "$OUTPUT_PATH"; then
+    echo "ERROR: failed to write scan output to $OUTPUT_PATH" >&2
+    exit 1
+fi
+
+echo "Windows VM broker scan completed successfully." >&2
+exit 0


### PR DESCRIPTION
- ad-scan.sh: Linux-broker AD scan via ldapsearch + embedded python3 (stdlib). Best of both PowerShell variants — membership inverted from each user's memberOf (no group-side ~5000 range truncation), CNF-group skip, name sanitization, paged results, group id = sAMAccountName. Fail-fast on inputs/commands; RootDSE query doubles as the bind test; empty/non-JSON/ write failures each emit a valid error JSON; password via 0600 file
- windows-scan.sh: Linux-broker Windows scan via WinRM (pywinrm) or SSH (powershell.exe -EncodedCommand), mirroring the temp-rdp-bridge transport. Remote PowerShell emits the Britive JSON; broker normalizes CRLF/BOM, validates (empty / PSERROR / non-JSON), and writes. Non-null email
- READMEs: AD README lays out ad-scan.ps1 vs ad-scan_2.ps1 (per-group vs bulk membership; large-group truncation trade-off) with when-to-use guidance, plus the shell version; Windows README documents the shell variant