### PR TITLE
Add dual account rotation demo scripts, docs, and hardening

### DIFF
--- a/Active Directory/rotate/Dual Account Rotation/.gitignore
+++ b/Active Directory/rotate/Dual Account Rotation/.gitignore
@@ -1,0 +1,2 @@
+# Local rehearsal credential file (cleartext) — never commit
+active.txt

--- a/Active Directory/rotate/Dual Account Rotation/Get-ActiveCred.ps1
+++ b/Active Directory/rotate/Dual Account Rotation/Get-ActiveCred.ps1
@@ -1,0 +1,61 @@
+# Get-ActiveCred.ps1
+# Returns the currently-active credential from a Britive dual-account secret.
+#
+# In dual-account rotation, only one of the two accounts (A or B) is "active" at
+# any moment. Retrieving the dual-account secret always yields the ACTIVE side,
+# so a consumer never has to know which account is live.
+
+function Get-ActiveCred {
+    [CmdletBinding()]
+    param(
+        [switch]$Simulate,
+        [string]$SecretPath = "/IT Secrets/WebApp Dual Account",
+        [string]$SimFile    = "$PSScriptRoot\active.txt"
+    )
+
+    $ErrorActionPreference = 'Stop'
+
+    if ($Simulate) {
+        # Rehearsal mode: read "username|password" from a local file.
+        # Flip A/B in this file by hand to fake a rotation.
+        if (-not (Test-Path $SimFile)) {
+            throw "Simulate mode: file not found: $SimFile (expected 'username|password')"
+        }
+        $line = (Get-Content $SimFile -Raw).Trim()
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            throw "Simulate mode: $SimFile is empty (expected 'username|password')"
+        }
+        $u, $p = $line -split '\|', 2
+        if ([string]::IsNullOrWhiteSpace($u) -or [string]::IsNullOrWhiteSpace($p)) {
+            throw "Simulate mode: malformed line in $SimFile (expected 'username|password')"
+        }
+        return [pscustomobject]@{ Username = $u; Password = $p }
+    }
+
+    # ---- REAL BRITIVE CALL (adjust field names to your secret template) ----
+    # Using pybritive; retrieving the dual-account secret yields the ACTIVE side.
+    if (-not (Get-Command pybritive -ErrorAction SilentlyContinue)) {
+        throw "pybritive CLI not found on PATH. Install it or use -Simulate."
+    }
+
+    $raw = pybritive secret view $SecretPath --format json 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "pybritive failed to read '$SecretPath': $raw"
+    }
+
+    try {
+        $json = $raw | ConvertFrom-Json
+    } catch {
+        throw "Could not parse pybritive output as JSON for '$SecretPath': $($_.Exception.Message)"
+    }
+
+    # Map these to your static-secret template's field names:
+    if (-not $json.account -or -not $json.password) {
+        throw "Secret '$SecretPath' missing expected fields 'account'/'password'."
+    }
+
+    return [pscustomobject]@{
+        Username = $json.account
+        Password = $json.password
+    }
+}

--- a/Active Directory/rotate/Dual Account Rotation/README.md
+++ b/Active Directory/rotate/Dual Account Rotation/README.md
@@ -1,0 +1,122 @@
+# Dual Account Rotation Demo
+
+This directory demonstrates **dual-account credential rotation** for an Active
+Directory service identity, fronted by the **Britive Vault**. It shows how a
+consumer can always fetch the currently-**active** credential without ever
+knowing which of the two backing accounts is live.
+
+## Why Dual-Account?
+
+A single service account has a hard problem: the moment you rotate its password,
+every consumer still holding the old password fails to authenticate until it
+re-fetches. There is an unavoidable outage window.
+
+Dual-account rotation removes that window. Two functionally identical accounts
+(`A` and `B`) share the same group membership and permissions. Only one is
+**active** at a time:
+
+1. `A` is active. Consumers authenticate with `A`.
+2. Rotation flips the active pointer to `B` (whose password is already valid).
+3. `A`'s password is then rotated in the background — no consumer was using it.
+4. Next rotation flips back to `A`, and so on.
+
+The Britive dual-account secret always returns the **active** side, so the
+consumer just asks the vault "give me the current credential" and never sees a
+failed bind.
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| `ad_setup.ps1` | One-time AD setup: creates the demo OU, shared group, and the two service accounts (`A`/`B`) that Britive will rotate. |
+| `Get-ActiveCred.ps1` | Function that returns the currently-active credential from the Britive dual-account secret (or a local file in simulate mode). |
+| `Watch-DualAuth.ps1` | Live auth timeline. Binds to AD on a loop and prints SUCCESS/FAIL so you can watch a rotation happen without an outage. |
+
+## Prerequisites
+
+- **Windows PowerShell 5.1** or later
+- **RSAT Active Directory module** (`Import-Module ActiveDirectory`)
+- Rights to create OUs, groups, and users in the target domain (for `ad_setup.ps1`)
+- **pybritive** CLI installed and authenticated (for live, non-simulate mode)
+- A Britive **dual-account secret** configured to return the active credential
+
+> The scripts default to a placeholder domain `example.local` /
+> `DC=example,DC=local`. Override with parameters (see Setup) to match your
+> directory. **Do not commit real domain, tenant, or credential values.**
+
+## Setup
+
+### 1. Create the AD objects
+
+```powershell
+.\ad_setup.ps1 `
+    -Domain    "corp.example.local" `
+    -OU        "OU=ServiceAccounts,DC=corp,DC=example,DC=local" `
+    -OUName    "ServiceAccounts" `
+    -OUPath    "DC=corp,DC=example,DC=local" `
+    -GroupName "svc-webapp" `
+    -AccountA  "svc-webapp-a" `
+    -AccountB  "svc-webapp-b"
+```
+
+The script prompts for the initial password (never hardcoded) and is safe to
+re-run — existing OU/group/accounts are skipped.
+
+### 2. Configure the Britive dual-account secret
+
+Create a static-secret template with `account` and `password` fields and register
+both AD accounts for dual-account rotation. Point `Get-ActiveCred.ps1`'s
+`-SecretPath` at the secret (default: `/IT Secrets/WebApp Dual Account`). Adjust
+the field-name mapping in `Get-ActiveCred.ps1` if your template uses different
+keys.
+
+### 3. Run the live watcher
+
+```powershell
+# Live: pulls the active credential from Britive every 3s
+.\Watch-DualAuth.ps1 -Domain "corp.example.local"
+
+# Baseline (the "before" case): pin one account and watch it break on rotation
+.\Watch-DualAuth.ps1 -Static svc-webapp-a -Domain "corp.example.local"
+```
+
+### Rehearse without a tenant (Simulate)
+
+You can rehearse the whole demo with no Britive tenant using a local file:
+
+```powershell
+# active.txt contains a single line: username|password
+"svc-webapp-a|CurrentP@ss" | Set-Content .\active.txt
+
+.\Watch-DualAuth.ps1 -Simulate -Domain "corp.example.local"
+```
+
+Edit `active.txt` by hand (flip to `svc-webapp-b|...`) to fake a rotation and
+watch the timeline follow the active side.
+
+## Fail-Fast & Error Handling
+
+All scripts set `$ErrorActionPreference = 'Stop'` and validate inputs before
+performing any AD or vault operation:
+
+- **`ad_setup.ps1`** — imports the AD module, prompts for the initial password,
+  and skips objects that already exist. Any failure exits `1` with a clear
+  message; success exits `0`.
+- **`Get-ActiveCred.ps1`** — validates the simulate file exists and is well-formed,
+  checks `pybritive` is on PATH, inspects the CLI exit code, parses JSON
+  defensively, and confirms the expected secret fields are present. Throws a
+  descriptive error otherwise.
+- **`Watch-DualAuth.ps1`** — fails fast at startup if the helper is missing or the
+  domain context cannot be built. The watch loop itself is intentionally
+  resilient: a transient per-tick error is logged and the timeline keeps ticking
+  through a rotation.
+
+## Security Notes
+
+- Passwords are **never printed** — the watcher masks all but the last two
+  characters.
+- The initial password in `ad_setup.ps1` is **prompted**, never hardcoded.
+- Britive owns rotation after setup; the AD accounts' `PasswordNeverExpires` flag
+  keeps AD from racing the vault.
+- Keep `active.txt` out of version control — it holds a cleartext credential and
+  is for local rehearsal only.

--- a/Active Directory/rotate/Dual Account Rotation/Watch-DualAuth.ps1
+++ b/Active Directory/rotate/Dual Account Rotation/Watch-DualAuth.ps1
@@ -1,0 +1,75 @@
+# Watch-DualAuth.ps1
+# Live auth timeline for the dual-account rotation demo.
+#
+#   .\Watch-DualAuth.ps1 -Simulate             # rehearse with active.txt, no tenant
+#   .\Watch-DualAuth.ps1                       # live against Britive dual-account secret
+#   .\Watch-DualAuth.ps1 -Static svc-webapp-a  # single-account BASELINE (watch it break)
+
+[CmdletBinding()]
+param(
+    [switch]$Simulate,
+    [string]$Static,                 # if set, pin to ONE account (the "before" case)
+    [string]$Domain   = "example.local",
+    [int]   $IntervalSeconds = 3,
+    [string]$StaticPassword          # only needed with -Static; prompts if omitted
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---- Fail-fast setup ----
+$helper = Join-Path $PSScriptRoot 'Get-ActiveCred.ps1'
+if (-not (Test-Path $helper)) {
+    Write-Error "Missing dependency: $helper"
+    exit 1
+}
+
+try {
+    . $helper
+    Add-Type -AssemblyName System.DirectoryServices.AccountManagement -ErrorAction Stop
+    $ctx = New-Object System.DirectoryServices.AccountManagement.PrincipalContext('Domain', $Domain)
+}
+catch {
+    Write-Error "Failed to initialize domain context for '$Domain': $($_.Exception.Message)"
+    exit 1
+}
+
+# Mask a password to just its last two chars, e.g. "hT6^ofXs" -> "******Xs"
+function Format-Masked([string]$s) {
+    if ([string]::IsNullOrEmpty($s)) { return "(none)" }
+    if ($s.Length -le 2) { return ('*' * $s.Length) }
+    return ('*' * ($s.Length - 2)) + $s.Substring($s.Length - 2)
+}
+
+if ($Static -and -not $StaticPassword) {
+    $StaticPassword = Read-Host "Password for $Static" -AsSecureString |
+        ForEach-Object { [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+            [Runtime.InteropServices.Marshal]::SecureStringToBSTR($_)) }
+}
+
+Write-Host "Watching auth every ${IntervalSeconds}s. Ctrl+C to stop.`n" -ForegroundColor Cyan
+
+# Loop is intentionally resilient: a transient error on one tick is logged and
+# the watch continues, so the timeline keeps ticking through a rotation.
+while ($true) {
+    $ts = Get-Date -Format "HH:mm:ss"
+    try {
+        if ($Static) {
+            $user = $Static; $pass = $StaticPassword; $res = $Domain   # baseline
+        } else {
+            $cred = Get-ActiveCred -Simulate:$Simulate                  # dual: active side
+            $user = $cred.Username; $pass = $cred.Password
+            $res  = if ($cred.Resource) { $cred.Resource } else { $Domain }
+        }
+
+        $masked = Format-Masked $pass
+        $ok = $ctx.ValidateCredentials($user, $pass)
+        if ($ok) {
+            Write-Host ("[{0}] SUCCESS  active={1,-14} resource={2,-10} pwd={3}" -f $ts, $user, $res, $masked) -ForegroundColor Green
+        } else {
+            Write-Host ("[{0}] FAIL     active={1,-14} resource={2,-10} pwd={3}  (bind rejected)" -f $ts, $user, $res, $masked) -ForegroundColor Red
+        }
+    } catch {
+        Write-Host "[$ts] FAIL     $($_.Exception.Message)" -ForegroundColor Red
+    }
+    Start-Sleep -Seconds $IntervalSeconds
+}

--- a/Active Directory/rotate/Dual Account Rotation/ad_setup.ps1
+++ b/Active Directory/rotate/Dual Account Rotation/ad_setup.ps1
@@ -1,0 +1,73 @@
+#Requires -Modules ActiveDirectory
+# ad_setup.ps1
+# One-time AD setup for the dual-account rotation demo.
+# Creates a demo OU, a shared security group, and two service accounts (A/B)
+# that Britive will rotate. Idempotent-ish: skips objects that already exist.
+#
+# Adjust the variables below to match your directory before running.
+
+[CmdletBinding()]
+param(
+    [string]$Domain     = "example.local",
+    [string]$OU         = "OU=BritiveDemo,DC=example,DC=local",
+    [string]$OUName     = "BritiveDemo",
+    [string]$OUPath     = "DC=example,DC=local",
+    [string]$GroupName  = "svc-webapp-demo",
+    [string]$AccountA   = "svc-webapp-a",
+    [string]$AccountB   = "svc-webapp-b"
+)
+
+$ErrorActionPreference = 'Stop'
+
+try {
+    Import-Module ActiveDirectory -ErrorAction Stop
+
+    # Initial password prompted (never hardcode); Britive owns rotation after setup.
+    $InitialPwd = Read-Host "Initial password for the demo service accounts" -AsSecureString
+
+    # Create the demo OU if it doesn't exist
+    if (-not (Get-ADOrganizationalUnit -Filter "DistinguishedName -eq '$OU'" -ErrorAction SilentlyContinue)) {
+        Write-Host "Creating OU '$OUName'..." -ForegroundColor Cyan
+        New-ADOrganizationalUnit -Name $OUName -Path $OUPath -ProtectedFromAccidentalDeletion $false -ErrorAction Stop
+    } else {
+        Write-Host "OU '$OU' already exists. Skipping." -ForegroundColor Yellow
+    }
+
+    # Create the shared group if it doesn't exist
+    if (-not (Get-ADGroup -Filter "Name -eq '$GroupName'" -ErrorAction SilentlyContinue)) {
+        Write-Host "Creating group '$GroupName'..." -ForegroundColor Cyan
+        New-ADGroup -Name $GroupName -GroupScope Global -GroupCategory Security -Path $OU `
+            -Description "Dual-account rotation demo (A/B web app identity)" -ErrorAction Stop
+    } else {
+        Write-Host "Group '$GroupName' already exists. Skipping." -ForegroundColor Yellow
+    }
+
+    # Create both service accounts if missing, then add to the shared group
+    foreach ($acct in @($AccountA, $AccountB)) {
+        if (-not (Get-ADUser -Filter "SamAccountName -eq '$acct'" -ErrorAction SilentlyContinue)) {
+            Write-Host "Creating account '$acct'..." -ForegroundColor Cyan
+            New-ADUser `
+                -Name                 $acct `
+                -SamAccountName        $acct `
+                -UserPrincipalName     "$acct@$Domain" `
+                -Path                  $OU `
+                -AccountPassword       $InitialPwd `
+                -PasswordNeverExpires  $true `
+                -CannotChangePassword  $false `
+                -Enabled               $true `
+                -Description           "Dual-account rotation demo identity" `
+                -ErrorAction Stop
+        } else {
+            Write-Host "Account '$acct' already exists. Skipping create." -ForegroundColor Yellow
+        }
+
+        Add-ADGroupMember -Identity $GroupName -Members $acct -ErrorAction Stop
+    }
+
+    Write-Host "Created/verified $AccountA and $AccountB in '$GroupName'. Britive will own rotation from here." -ForegroundColor Green
+    exit 0
+}
+catch {
+    Write-Error "AD setup failed: $($_.Exception.Message)"
+    exit 1
+}


### PR DESCRIPTION
Anonymize domain references (example.local), add fail-fast and error handling to ad_setup, Get-ActiveCred, and Watch-DualAuth, and add README with setup instructions and a .gitignore for the local rehearsal credential file.