### PR TITLE
Restore Bridge admin scripts; they were never v1

### DIFF
--- a/Bridge/permissions/admin/README.md
+++ b/Bridge/permissions/admin/README.md
@@ -1,0 +1,87 @@
+# Bridge admin access
+
+Checkout / checkin scripts that grant a Britive identity **Bridge administrator
+powers for the lifetime of a checkout**, then take them away again.
+
+Unlike every other pattern in this repo, this one provisions nothing on a target
+host. There is no temporary account, no key, and no proxied session — the
+checkout *is* the grant.
+
+## What an admin can do
+
+A Bridge administrator can create and revoke checkouts, view and live-watch every
+session, lock / unlock / force-disconnect sessions, issue and revoke share links,
+and install or remove licenses.
+
+Administrator status normally comes from your **identity provider** — an admin
+group mapped at login. These scripts are the alternative: a bounded, audited
+window granted through the same JIT checkout flow as everything else, so nobody
+has to sit in a standing admin group.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `bridge_admin_checkout.sh` | Register a role checkout; return the admin console URL |
+| `bridge_admin_checkin.sh`  | Delete the checkout, ending the grant |
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `TRANSACTION_ID` | Yes | Britive transaction ID for this checkout |
+| `ROLE` | Yes | Role to grant — `admin`, or `auditor` for scoped oversight |
+| `USERNAME` | Yes | The Britive identity receiving the role |
+| `EXPIRATION` | Yes | Grant duration in seconds — **checkout only** |
+| `BRIDGE_URL` | Yes | Bridge hostname — **checkout only** |
+
+`ROLE` is a variable rather than a hardcoded `admin` so one pair of scripts can
+back both an admin profile and a lower-privilege `auditor` profile. See
+[Roles: user, auditor, admin](https://learn.britive.com/bridge/checkouts/roles/)
+for what each one carries.
+
+## How It Works
+
+### Checkout
+
+Registers a checkout carrying `role` and `username` and nothing else — no
+protocol, no target, no credential:
+
+```json
+{
+  "transaction_id": "<TRX>",
+  "role": "admin",
+  "username": "grace@corp",
+  "expires_at": 1750000000
+}
+```
+
+The Bridge authorizes from the user's session plus this active checkout. **There
+is no token to hand out** — the returned URL is just where to go:
+
+```json
+{ "browser_session": "https://bridge.example.com/user-sessions" }
+```
+
+A response template can surface `{{browser_session}}`, matching the key the SSH,
+RDP and database bridge patterns emit.
+
+### Checkin
+
+Deletes the checkout, which ends the grant immediately. The user drops back to
+whatever role their identity provider gives them.
+
+## Broker Container Requirements
+
+`/opt/britive-broker/scripts/bridge.sh`, which the Bridge image ships as a
+symlink to `broker-bridge-api.sh`. Either name works.
+
+## Security Notes
+
+- The grant lives and dies with the transaction. `expires_at` bounds it even if
+  checkin never runs.
+- Nothing is written to a target host, so a failed checkin cannot leave a
+  credential behind — the worst case is an admin grant that persists until
+  `expires_at`.
+- Scope `ROLE` to `auditor` wherever oversight is enough. An `admin` checkout can
+  revoke other people's sessions and manage licenses.

--- a/Bridge/permissions/admin/bridge_admin_checkin.sh
+++ b/Bridge/permissions/admin/bridge_admin_checkin.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+/opt/britive-broker/scripts/bridge.sh checkout-delete "${TRANSACTION_ID}"

--- a/Bridge/permissions/admin/bridge_admin_checkout.sh
+++ b/Bridge/permissions/admin/bridge_admin_checkout.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Checkout: register a role=admin checkout so the logged-in user gains admin-UI
+# access (the review/admin surface at /user-sessions) for its lifetime. No token —
+# the bridge authorizes from the session + this active admin checkout.
+set -eu
+
+NOW_EPOCH=$(date +%s)
+EXPIRES_AT=$((NOW_EPOCH + EXPIRATION))
+cat <<EOF | /opt/britive-broker/scripts/bridge.sh checkout-create --stdin >/dev/null
+{
+  "transaction_id": "${TRANSACTION_ID}",
+  "role": "${ROLE}",
+  "username": "${USERNAME}",
+  "expires_at": ${EXPIRES_AT}
+}
+EOF
+printf '{"browser_session": "https://%s/user-sessions"}\n' "${BRIDGE_URL}"


### PR DESCRIPTION
Commit 1ce3e2b deleted Bridge/permissions/admin as a Bridge v1 pattern with no v2 port. That was wrong. The classification used "calls /opt/britive-broker/scripts/bridge.sh" as the v1 marker, but in the v2 image that path is a symlink:

  bridge.sh -> broker-bridge-api.sh

It is a compatibility alias, not a version signal. The scripts work on v2 and always did.

The pattern itself is documented v2 behaviour: an admin-role checkout grants a Britive identity Bridge administrator powers for the checkout's lifetime, which is exactly what learn.britive.com/bridge/checkouts/roles/ describes. The payload carries role and username and nothing else -- no protocol, no target, no credential -- so the absence of native_auth and target_host is correct here rather than evidence of an older format.

Restored with two improvements over the deleted version:

- role is a variable instead of a hardcoded "admin", so one pair of scripts backs both an admin profile and a lower-privilege auditor profile.
- The output key is browser_session, matching what the SSH, RDP and database bridge patterns emit, so one response template covers all of them. It was bridge_url before.

The checkin script is renamed from birdge_admin_checkin.sh, correcting a typo. Nothing in the repo referenced the old path.

Adds a README, which the directory never had.

k8s/permissions/k8s-exec-bridge was deleted on the same wrong basis. It uses protocol k8sexec and a token, both valid in the v2 payload reference, so it is very likely fine too -- but it has not been exercised against a v2 Bridge, so it stays out until someone runs it rather than being restored on another assumption.